### PR TITLE
Refactor dashboard and chat flows into testable view models

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,10 +34,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
+
 }
 
 kotlin {
@@ -47,41 +47,41 @@ kotlin {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.11.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation 'androidx.vectordrawable:vectordrawable:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.fragment:fragment-ktx:1.6.2'
-    implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.6'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.7.6'
+    implementation 'androidx.fragment:fragment-ktx:1.8.9'
+    implementation 'androidx.core:core-ktx:1.17.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.9.5'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.9.5'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 
-    implementation platform('com.google.firebase:firebase-bom:32.7.1')
+    implementation platform('com.google.firebase:firebase-bom:34.3.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-firestore-ktx'
     implementation 'com.google.firebase:firebase-auth-ktx'
     implementation 'com.google.firebase:firebase-storage-ktx'
     implementation 'com.google.firebase:firebase-messaging-ktx'
-    implementation 'com.firebaseui:firebase-ui-auth:8.0.2'
-    implementation 'com.firebaseui:firebase-ui-storage:8.0.2'
-    implementation 'com.google.android.gms:play-services-auth:20.7.0'
+    implementation 'com.firebaseui:firebase-ui-auth:9.0.0'
+    implementation 'com.firebaseui:firebase-ui-storage:9.0.0'
+    implementation 'com.google.android.gms:play-services-auth:21.4.0'
 
-    implementation 'com.github.bumptech.glide:glide:4.16.0'
-    kapt 'com.github.bumptech.glide:compiler:4.16.0'
-    kapt 'com.github.bumptech.glide:annotations:4.16.0'
+    implementation 'com.github.bumptech.glide:glide:5.0.5'
+    kapt 'com.github.bumptech.glide:compiler:5.0.5'
+    kapt 'com.github.bumptech.glide:annotations:5.0.5'
     implementation 'com.jakewharton.timber:timber:5.0.1'
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"
-    implementation "androidx.lifecycle:lifecycle-common-java8:2.6.2"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.9.4"
+    implementation "androidx.lifecycle:lifecycle-common-java8:2.9.4"
 
     implementation 'com.github.lisawray.groupie:groupie:2.10.1'
     implementation 'com.github.lisawray.groupie:groupie-viewbinding:2.10.1'
 
-    implementation "io.insert-koin:koin-android:3.5.6"
+    implementation "io.insert-koin:koin-android:4.1.1"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.7.6'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'androidx.arch.core:core-testing:2.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 

--- a/app/src/main/java/com/example/rise/App.kt
+++ b/app/src/main/java/com/example/rise/App.kt
@@ -9,12 +9,17 @@ import com.example.rise.auth.FirebaseUserSessionProvider
 import com.example.rise.auth.SignInIntentProvider
 import com.example.rise.auth.UserSessionProvider
 import com.example.rise.ui.SplashActivityViewModel
+import com.example.rise.ui.dashboardNavigation.dashboard.DashboardRepository
 import com.example.rise.ui.dashboardNavigation.dashboard.DashboardViewModel
+import com.example.rise.ui.dashboardNavigation.dashboard.FirestoreDashboardRepository
 import com.example.rise.ui.dashboardNavigation.myAccount.MyAccountBaseViewModel
 import com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatViewModel
 import com.example.rise.ui.dashboardNavigation.people.peopleFragment.PeopleViewModel
 import com.example.rise.ui.mainActivity.MainActivityViewModel
 import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInViewModel
+import com.example.rise.ui.dashboardNavigation.people.chatActivity.FirestoreChatRepository
+import com.example.rise.ui.dashboardNavigation.people.peopleFragment.FirestorePeopleRepository
+import com.example.rise.ui.dashboardNavigation.people.peopleFragment.PeopleRepository
 import com.firebase.ui.auth.AuthUI
 import com.google.firebase.firestore.FirebaseFirestore
 import org.koin.android.ext.koin.androidContext
@@ -33,15 +38,9 @@ class App : Application() {
         factory<AuthStateProvider> { FirebaseAuthStateProvider(get()) }
         factory<SignInIntentProvider> { FirebaseAuthUiSignInIntentProvider(get()) }
         single<UserSessionProvider> { FirebaseUserSessionProvider(get()) }
-        single<com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatRepository> {
-            com.example.rise.ui.dashboardNavigation.people.chatActivity.FirestoreChatRepository(get())
-        }
-        single<com.example.rise.ui.dashboardNavigation.people.peopleFragment.PeopleRepository> {
-            com.example.rise.ui.dashboardNavigation.people.peopleFragment.FirestorePeopleRepository(get())
-        }
-        single<com.example.rise.ui.dashboardNavigation.dashboard.DashboardRepository> {
-            com.example.rise.ui.dashboardNavigation.dashboard.FirestoreDashboardRepository(get(), get())
-        }
+        single<com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatRepository> { FirestoreChatRepository(get()) }
+        single<PeopleRepository> { FirestorePeopleRepository(get()) }
+        single<DashboardRepository> { FirestoreDashboardRepository(get(), get()) }
         viewModel { SplashActivityViewModel(get()) }
         viewModel { MyAccountBaseViewModel() }
         viewModel { DashboardViewModel(get(), get()) }
@@ -54,7 +53,6 @@ class App : Application() {
     override fun onCreate() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
-
         startKoin {
             //Koin android logger
             androidLogger()

--- a/app/src/main/java/com/example/rise/App.kt
+++ b/app/src/main/java/com/example/rise/App.kt
@@ -1,28 +1,54 @@
 package com.example.rise
 
 import android.app.Application
-import android.provider.Contacts
+import com.google.firebase.auth.FirebaseAuth
+import com.example.rise.auth.AuthStateProvider
+import com.example.rise.auth.FirebaseAuthStateProvider
+import com.example.rise.auth.FirebaseAuthUiSignInIntentProvider
+import com.example.rise.auth.FirebaseUserSessionProvider
+import com.example.rise.auth.SignInIntentProvider
+import com.example.rise.auth.UserSessionProvider
 import com.example.rise.ui.SplashActivityViewModel
 import com.example.rise.ui.dashboardNavigation.dashboard.DashboardViewModel
 import com.example.rise.ui.dashboardNavigation.myAccount.MyAccountBaseViewModel
 import com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatViewModel
 import com.example.rise.ui.dashboardNavigation.people.peopleFragment.PeopleViewModel
 import com.example.rise.ui.mainActivity.MainActivityViewModel
+import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInViewModel
+import com.firebase.ui.auth.AuthUI
+import com.google.firebase.firestore.FirebaseFirestore
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
 import timber.log.Timber
 
-class App: Application() {
+class App : Application() {
 
     val appModule = module {
-        factory { SplashActivityViewModel() }
-        factory { MyAccountBaseViewModel() }
-        factory { DashboardViewModel() }
-        factory { ChatViewModel() }
-        factory { PeopleViewModel() }
-        factory { MainActivityViewModel() }
+        single { FirebaseAuth.getInstance() }
+        single { AuthUI.getInstance() }
+        single { FirebaseFirestore.getInstance() }
+        factory<AuthStateProvider> { FirebaseAuthStateProvider(get()) }
+        factory<SignInIntentProvider> { FirebaseAuthUiSignInIntentProvider(get()) }
+        single<UserSessionProvider> { FirebaseUserSessionProvider(get()) }
+        single<com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatRepository> {
+            com.example.rise.ui.dashboardNavigation.people.chatActivity.FirestoreChatRepository(get())
+        }
+        single<com.example.rise.ui.dashboardNavigation.people.peopleFragment.PeopleRepository> {
+            com.example.rise.ui.dashboardNavigation.people.peopleFragment.FirestorePeopleRepository(get())
+        }
+        single<com.example.rise.ui.dashboardNavigation.dashboard.DashboardRepository> {
+            com.example.rise.ui.dashboardNavigation.dashboard.FirestoreDashboardRepository(get(), get())
+        }
+        viewModel { SplashActivityViewModel(get()) }
+        viewModel { MyAccountBaseViewModel() }
+        viewModel { DashboardViewModel(get(), get()) }
+        viewModel { ChatViewModel(get()) }
+        viewModel { PeopleViewModel(get()) }
+        viewModel { MainActivityViewModel(get(), get()) }
+        viewModel { SignInViewModel() }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/example/rise/auth/AuthStateProvider.kt
+++ b/app/src/main/java/com/example/rise/auth/AuthStateProvider.kt
@@ -1,0 +1,5 @@
+package com.example.rise.auth
+
+fun interface AuthStateProvider {
+    fun isUserSignedIn(): Boolean
+}

--- a/app/src/main/java/com/example/rise/auth/FirebaseAuthStateProvider.kt
+++ b/app/src/main/java/com/example/rise/auth/FirebaseAuthStateProvider.kt
@@ -1,0 +1,10 @@
+package com.example.rise.auth
+
+import com.google.firebase.auth.FirebaseAuth
+
+class FirebaseAuthStateProvider(
+    private val firebaseAuth: FirebaseAuth
+) : AuthStateProvider {
+
+    override fun isUserSignedIn(): Boolean = firebaseAuth.currentUser != null
+}

--- a/app/src/main/java/com/example/rise/auth/FirebaseAuthUiSignInIntentProvider.kt
+++ b/app/src/main/java/com/example/rise/auth/FirebaseAuthUiSignInIntentProvider.kt
@@ -1,0 +1,18 @@
+package com.example.rise.auth
+
+import android.content.Intent
+import com.firebase.ui.auth.AuthUI
+
+class FirebaseAuthUiSignInIntentProvider(
+    private val authUI: AuthUI,
+    private val providers: List<AuthUI.IdpConfig> = listOf(AuthUI.IdpConfig.EmailBuilder().build()),
+    private val isSmartLockEnabled: Boolean = false
+) : SignInIntentProvider {
+
+    override fun createSignInIntent(): Intent {
+        return authUI.createSignInIntentBuilder()
+            .setAvailableProviders(providers)
+            .setIsSmartLockEnabled(isSmartLockEnabled)
+            .build()
+    }
+}

--- a/app/src/main/java/com/example/rise/auth/FirebaseUserSessionProvider.kt
+++ b/app/src/main/java/com/example/rise/auth/FirebaseUserSessionProvider.kt
@@ -1,0 +1,13 @@
+package com.example.rise.auth
+
+import com.google.firebase.auth.FirebaseAuth
+
+class FirebaseUserSessionProvider(
+    private val firebaseAuth: FirebaseAuth
+) : UserSessionProvider {
+
+    override fun currentUserId(): String =
+        firebaseAuth.currentUser?.uid ?: throw IllegalStateException("UID is null.")
+
+    override fun currentUserName(): String = firebaseAuth.currentUser?.displayName.orEmpty()
+}

--- a/app/src/main/java/com/example/rise/auth/SignInIntentProvider.kt
+++ b/app/src/main/java/com/example/rise/auth/SignInIntentProvider.kt
@@ -1,0 +1,7 @@
+package com.example.rise.auth
+
+import android.content.Intent
+
+fun interface SignInIntentProvider {
+    fun createSignInIntent(): Intent
+}

--- a/app/src/main/java/com/example/rise/auth/UserSessionProvider.kt
+++ b/app/src/main/java/com/example/rise/auth/UserSessionProvider.kt
@@ -1,0 +1,6 @@
+package com.example.rise.auth
+
+interface UserSessionProvider {
+    fun currentUserId(): String
+    fun currentUserName(): String
+}

--- a/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
@@ -1,9 +1,9 @@
 package com.example.rise.baseclasses
 
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.ViewModelLazy
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
+import kotlin.LazyThreadSafetyMode
 import kotlin.reflect.KClass
 import org.koin.android.ext.android.getKoinScope
 import org.koin.androidx.viewmodel.factory.KoinViewModelFactory
@@ -28,10 +28,10 @@ abstract class BaseActivity<VM : BaseViewModel> : AppCompatActivity() {
         )
     }
 
-    protected val viewModel: VM by ViewModelLazy(
-        viewModelClass,
-        { viewModelStore },
-        { provideViewModelFactory() },
-        { defaultViewModelExtras() }
-    )
+    protected val viewModel: VM by lazy(LazyThreadSafetyMode.NONE) {
+        ViewModelProvider(
+            viewModelStore,
+            provideViewModelFactory()
+        )[viewModelClass.java]
+    }
 }

--- a/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
@@ -1,16 +1,37 @@
 package com.example.rise.baseclasses
 
-import android.os.Bundle
-import android.os.PersistableBundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelLazy
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import kotlin.reflect.KClass
+import org.koin.android.ext.android.getKoinScope
+import org.koin.androidx.viewmodel.factory.KoinViewModelFactory
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
 
+@OptIn(KoinInternalApi::class)
+abstract class BaseActivity<VM : BaseViewModel> : AppCompatActivity() {
 
-abstract class BaseActivity<viewModel: BaseViewModel>: AppCompatActivity() {
-    lateinit var  viewModel: viewModel
-    abstract fun createViewModel()
+    protected abstract val viewModelClass: KClass<VM>
+    protected open val viewModelQualifier: Qualifier? = null
+    protected open val viewModelParameters: ParametersDefinition? = null
+    protected open fun defaultViewModelExtras(): CreationExtras = defaultViewModelCreationExtras
 
-    override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
-        super.onCreate(savedInstanceState, persistentState)
-        createViewModel()
+    protected open fun provideViewModelFactory(): ViewModelProvider.Factory {
+        return KoinViewModelFactory(
+            viewModelClass,
+            getKoinScope(),
+            viewModelQualifier,
+            viewModelParameters
+        )
     }
+
+    protected val viewModel: VM by ViewModelLazy(
+        viewModelClass,
+        { viewModelStore },
+        { provideViewModelFactory() },
+        { defaultViewModelExtras() }
+    )
 }

--- a/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
@@ -1,14 +1,37 @@
 package com.example.rise.baseclasses
 
-import android.os.Bundle
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelLazy
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import kotlin.reflect.KClass
+import org.koin.android.ext.android.getKoinScope
+import org.koin.androidx.viewmodel.factory.KoinViewModelFactory
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
 
-abstract class BaseFragment<viewModel: BaseViewModel>: Fragment() {
-    lateinit var viewModel: viewModel
-    abstract fun createViewModel()
+@OptIn(KoinInternalApi::class)
+abstract class BaseFragment<VM : BaseViewModel> : Fragment() {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        createViewModel()
+    protected abstract val viewModelClass: KClass<VM>
+    protected open val viewModelQualifier: Qualifier? = null
+    protected open val viewModelParameters: ParametersDefinition? = null
+    protected open fun defaultViewModelExtras(): CreationExtras = defaultViewModelCreationExtras
+
+    protected open fun provideViewModelFactory(): ViewModelProvider.Factory {
+        return KoinViewModelFactory(
+            viewModelClass,
+            getKoinScope(),
+            viewModelQualifier,
+            viewModelParameters
+        )
     }
+
+    protected val viewModel: VM by ViewModelLazy(
+        viewModelClass,
+        { viewModelStore },
+        { provideViewModelFactory() },
+        { defaultViewModelExtras() }
+    )
 }

--- a/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
@@ -1,9 +1,9 @@
 package com.example.rise.baseclasses
 
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelLazy
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
+import kotlin.LazyThreadSafetyMode
 import kotlin.reflect.KClass
 import org.koin.android.ext.android.getKoinScope
 import org.koin.androidx.viewmodel.factory.KoinViewModelFactory
@@ -28,10 +28,10 @@ abstract class BaseFragment<VM : BaseViewModel> : Fragment() {
         )
     }
 
-    protected val viewModel: VM by ViewModelLazy(
-        viewModelClass,
-        { viewModelStore },
-        { provideViewModelFactory() },
-        { defaultViewModelExtras() }
-    )
+    protected val viewModel: VM by lazy(LazyThreadSafetyMode.NONE) {
+        ViewModelProvider(
+            viewModelStore,
+            provideViewModelFactory()
+        ).get(viewModelClass.java)
+    }
 }

--- a/app/src/main/java/com/example/rise/ui/SplashActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/SplashActivity.kt
@@ -1,33 +1,26 @@
 package com.example.rise.ui
 
-
 import android.content.Intent
 import android.os.Bundle
 
 import com.example.rise.baseclasses.BaseActivity
-import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInActivity
 import com.example.rise.ui.mainActivity.MainActivity
 import com.google.firebase.FirebaseApp
-import com.google.firebase.auth.FirebaseAuth
-import org.koin.android.ext.android.get
-import org.koin.dsl.koinApplication
+import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInActivity
 
 class SplashActivity : BaseActivity<SplashActivityViewModel>() {
+
+    override val viewModelClass = SplashActivityViewModel::class
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         FirebaseApp.initializeApp(this)
-        if (FirebaseAuth.getInstance().currentUser == null) {
-            val intent = Intent(this, SignInActivity::class.java)
-            startActivity(intent)
-        } else {
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
+        val destination = viewModel.resolveDestination()
+        val target = when (destination) {
+            SplashActivityViewModel.Destination.SIGN_IN -> SignInActivity::class.java
+            SplashActivityViewModel.Destination.MAIN -> MainActivity::class.java
         }
+        startActivity(Intent(this, target))
         finish()
-    }
-
-    override fun createViewModel() {
-        viewModel = get()
     }
 }

--- a/app/src/main/java/com/example/rise/ui/SplashActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/SplashActivity.kt
@@ -8,6 +8,7 @@ import com.example.rise.ui.mainActivity.MainActivity
 import com.google.firebase.FirebaseApp
 import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInActivity
 
+//TODO Investigate SplashScreen
 class SplashActivity : BaseActivity<SplashActivityViewModel>() {
 
     override val viewModelClass = SplashActivityViewModel::class

--- a/app/src/main/java/com/example/rise/ui/SplashActivityViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/SplashActivityViewModel.kt
@@ -1,7 +1,23 @@
 package com.example.rise.ui
 
+import com.example.rise.auth.AuthStateProvider
 import com.example.rise.baseclasses.BaseViewModel
 
-class SplashActivityViewModel: BaseViewModel() {
+class SplashActivityViewModel(
+    private val authStateProvider: AuthStateProvider
+) : BaseViewModel() {
+
+    enum class Destination {
+        SIGN_IN,
+        MAIN
+    }
+
+    fun resolveDestination(): Destination {
+        return if (authStateProvider.isUserSignedIn()) {
+            Destination.MAIN
+        } else {
+            Destination.SIGN_IN
+        }
+    }
 
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardFragment.kt
@@ -8,61 +8,36 @@ import android.view.ViewGroup
 import android.widget.DatePicker
 import androidx.annotation.RequiresApi
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.rise.R
 import com.example.rise.baseclasses.BaseFragment
 import com.example.rise.databinding.FragmentDashboardBinding
 import com.example.rise.extensions.scheduleNextAlarm
-import com.example.rise.helpers.CHAT_CHANNEL
-import com.example.rise.helpers.MESSAGE_CONTENT
-import com.example.rise.helpers.MINUTE_SECONDS
 import com.example.rise.models.Alarm
 import com.example.rise.models.TextMessage
 import com.example.rise.ui.dashboardNavigation.dashboard.recyclerview.MyFireStoreAlarmRecyclerViewAdapter
 import com.google.android.material.snackbar.Snackbar
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.FieldValue
-import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.firestore.Query
-import org.koin.android.ext.android.get
-import timber.log.Timber
 import java.util.Calendar
 
 class DashboardFragment : BaseFragment<DashboardViewModel>() {
 
+    override val viewModelClass = DashboardViewModel::class
+
     var byBottomNavigation: Boolean = false
 
-    private lateinit var mQuery: Query
-    private lateinit var myFireStoreAlarmRecyclerViewAdapter: MyFireStoreAlarmRecyclerViewAdapter
-    private val tag = "DASHBOARD_FRAGMENT"
-
-    private var firstrun: Boolean = true
-    private var userID: String? = null
-    private lateinit var alarm: Alarm
-
-    private val firestoreInstance: FirebaseFirestore by lazy { FirebaseFirestore.getInstance() }
-
-    private var mFirestore: DocumentReference = firestoreInstance.document(
-        "users/${FirebaseAuth.getInstance().currentUser?.uid ?: throw NullPointerException("UID is null.")}"
-    )
+    private var adapter: MyFireStoreAlarmRecyclerViewAdapter? = null
 
     private var _binding: FragmentDashboardBinding? = null
     private val binding get() = _binding!!
 
     override fun onStart() {
         super.onStart()
-        if (::myFireStoreAlarmRecyclerViewAdapter.isInitialized) {
-            myFireStoreAlarmRecyclerViewAdapter.startListening()
-        }
+        adapter?.startListening()
     }
 
     override fun onStop() {
         super.onStop()
-        if (::myFireStoreAlarmRecyclerViewAdapter.isInitialized) {
-            myFireStoreAlarmRecyclerViewAdapter.stopListening()
-        }
+        adapter?.stopListening()
     }
 
     override fun onCreateView(
@@ -77,92 +52,76 @@ class DashboardFragment : BaseFragment<DashboardViewModel>() {
     @RequiresApi(Build.VERSION_CODES.M)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        FirebaseFirestore.setLoggingEnabled(true)
 
         binding.floatingActionButton.setOnClickListener {
-            alarm = Alarm()
-            firstrun = false
-
-            alarm.chatChannel = activity?.intent?.getStringExtra(CHAT_CHANNEL).orEmpty()
-            alarm.messsage = activity?.intent?.getParcelableExtra<TextMessage>(MESSAGE_CONTENT)
-            alarm.userName = FirebaseAuth.getInstance().currentUser?.displayName.orEmpty()
-
-            val datePicker = DatePicker(view.context)
-            val cal: Calendar = Calendar.getInstance()
-
-            cal.set(Calendar.DAY_OF_MONTH, datePicker.dayOfMonth)
-            cal.set(Calendar.MONTH, datePicker.month)
-            cal.set(Calendar.YEAR, datePicker.year)
-            cal.set(Calendar.HOUR_OF_DAY, binding.simpleTimePicker.hour)
-            cal.set(Calendar.MINUTE, binding.simpleTimePicker.minute)
-
-            val millis: Long = cal.timeInMillis
-
-            alarm.timeInMiliseconds = millis
-            alarm.idTimeStamp = System.currentTimeMillis().toInt()
-
-            if (alarm.messsage != null) {
-                context?.scheduleNextAlarm(alarm, true)
-            }
-
-            mQuery = queryFirestore()
+            val millis = buildSelectedTimeMillis()
+            viewModel.createAlarm(millis)
         }
 
-        val userID: String? = activity?.intent?.getStringExtra("UsrID")
+        val userId: String? = activity?.intent?.getStringExtra("UsrID")
         val chatChannel: String? = activity?.intent?.getStringExtra("ChannelId")
-        val message = activity?.intent?.getParcelableExtra<TextMessage>("Message")
+        val message: TextMessage? = activity?.intent?.getParcelableExtra("Message")
 
-        if (userID != null && !byBottomNavigation) {
-            this.userID = userID
-            mFirestore = firestoreInstance.document(
-                "users/$userID"
-            )
-        }
-
-        alarm = Alarm()
-        alarm.chatChannel = chatChannel.orEmpty()
-        alarm.messsage = message
-        mQuery = queryFirestore()
-        initRecyclerView(mQuery)
+        observeViewModel()
+        viewModel.initialize(userId, chatChannel, message, byBottomNavigation)
     }
 
-    private fun queryFirestore(): CollectionReference {
-        if (!firstrun) {
-            mFirestore.collection("alarms")
-            mFirestore.update("id", FieldValue.increment(1))
-            mFirestore.collection("alarms")
-                .document(alarm.idTimeStamp.toString()).set(alarm)
-                .addOnSuccessListener {
-                    Timber.d("DocumentSnapshot add with ID: ")
-                }
-                .addOnFailureListener { e ->
-                    Timber.tag(tag).w(e, "Error adding document")
-                }
+    private fun buildSelectedTimeMillis(): Long {
+        val datePicker = DatePicker(requireContext())
+        return Calendar.getInstance().apply {
+            set(Calendar.DAY_OF_MONTH, datePicker.dayOfMonth)
+            set(Calendar.MONTH, datePicker.month)
+            set(Calendar.YEAR, datePicker.year)
+            set(Calendar.HOUR_OF_DAY, binding.simpleTimePicker.hour)
+            set(Calendar.MINUTE, binding.simpleTimePicker.minute)
+        }.timeInMillis
+    }
+
+    private fun observeViewModel() {
+        viewModel.alarmQuery.observe(viewLifecycleOwner) { alarmQuery ->
+            val query = (alarmQuery as? FirestoreAlarmQuery)?.unwrap()
+            if (query != null) {
+                initRecyclerView(query)
+            }
         }
-        return mFirestore.collection("alarms")
+
+        viewModel.otherUserId.observe(viewLifecycleOwner) { otherUserId ->
+            adapter?.otherUsrId = otherUserId
+        }
+
+        viewModel.events.observe(viewLifecycleOwner) { event ->
+            when (val content = event.getContentIfNotHandled()) {
+                is DashboardViewModel.DashboardEvent.ScheduleAlarm -> scheduleAlarm(content.alarm)
+                null -> Unit
+            }
+        }
     }
 
     private fun initRecyclerView(query: Query) {
-        myFireStoreAlarmRecyclerViewAdapter = object : MyFireStoreAlarmRecyclerViewAdapter(query, requireContext()) {
-            override fun onError(e: FirebaseFirestoreException) = Snackbar.make(
-                binding.root,
-                "Error: check logs for info.",
-                Snackbar.LENGTH_LONG
-            ).show()
+        if (adapter == null) {
+            adapter = object : MyFireStoreAlarmRecyclerViewAdapter(query, requireContext()) {
+                override fun onError(e: FirebaseFirestoreException) = Snackbar.make(
+                    binding.root,
+                    "Error: check logs for info.",
+                    Snackbar.LENGTH_LONG
+                ).show()
+            }
+            binding.alarmList.layoutManager = LinearLayoutManager(context)
+            binding.alarmList.adapter = adapter
+        } else {
+            adapter?.setQuery(query)
         }
+        adapter?.startListening()
+    }
 
-        myFireStoreAlarmRecyclerViewAdapter.otherUsrId = this.userID
-        binding.alarmList.layoutManager = LinearLayoutManager(context)
-        binding.alarmList.adapter = myFireStoreAlarmRecyclerViewAdapter
-        myFireStoreAlarmRecyclerViewAdapter.setQuery(query)
+    private fun scheduleAlarm(alarm: Alarm) {
+        context?.scheduleNextAlarm(alarm, true)
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
+        adapter?.stopListening()
+        adapter = null
         _binding = null
-    }
-
-    override fun createViewModel() {
-        viewModel = get()
     }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardRepository.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardRepository.kt
@@ -1,0 +1,21 @@
+package com.example.rise.ui.dashboardNavigation.dashboard
+
+import com.example.rise.models.Alarm
+import com.google.firebase.firestore.Query
+
+interface AlarmQuery {
+    fun unwrap(): Query
+}
+
+data class FirestoreAlarmQuery(private val query: Query) : AlarmQuery {
+    override fun unwrap(): Query = query
+}
+
+data class UserHandle(val userId: String)
+
+interface DashboardRepository {
+    fun resolveUser(userId: String? = null): UserHandle
+    fun buildAlarmQuery(handle: UserHandle): AlarmQuery
+    fun incrementAlarmId(handle: UserHandle)
+    fun saveAlarm(handle: UserHandle, alarm: Alarm)
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModel.kt
@@ -1,6 +1,71 @@
 package com.example.rise.ui.dashboardNavigation.dashboard
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.example.rise.auth.UserSessionProvider
 import com.example.rise.baseclasses.BaseViewModel
+import com.example.rise.models.Alarm
+import com.example.rise.models.TextMessage
+import com.example.rise.util.Event
 
-class DashboardViewModel: BaseViewModel() {
+class DashboardViewModel(
+    private val repository: DashboardRepository,
+    private val userSessionProvider: UserSessionProvider
+) : BaseViewModel() {
+
+    sealed class DashboardEvent {
+        data class ScheduleAlarm(val alarm: Alarm) : DashboardEvent()
+    }
+
+    private val _alarmQuery = MutableLiveData<AlarmQuery?>()
+    val alarmQuery: LiveData<AlarmQuery?> = _alarmQuery
+
+    private val _events = MutableLiveData<Event<DashboardEvent>>()
+    val events: LiveData<Event<DashboardEvent>> = _events
+
+    private val _otherUserId = MutableLiveData<String?>()
+    val otherUserId: LiveData<String?> = _otherUserId
+
+    private var userHandle: UserHandle? = null
+    private var pendingMessage: TextMessage? = null
+    private var pendingChatChannel: String = ""
+
+    fun initialize(
+        userIdFromIntent: String?,
+        chatChannel: String?,
+        message: TextMessage?,
+        launchedFromBottomNavigation: Boolean
+    ) {
+        pendingMessage = message
+        pendingChatChannel = chatChannel.orEmpty()
+
+        val resolvedUserId = if (!launchedFromBottomNavigation && userIdFromIntent != null) {
+            _otherUserId.value = userIdFromIntent
+            userIdFromIntent
+        } else {
+            _otherUserId.value = null
+            null
+        }
+
+        userHandle = repository.resolveUser(resolvedUserId)
+        _alarmQuery.value = userHandle?.let { repository.buildAlarmQuery(it) }
+    }
+
+    fun createAlarm(timeInMillis: Long) {
+        val handle = userHandle ?: return
+        val alarm = Alarm().apply {
+            chatChannel = pendingChatChannel
+            messsage = pendingMessage
+            userName = userSessionProvider.currentUserName()
+            timeInMiliseconds = timeInMillis
+            idTimeStamp = System.currentTimeMillis().toInt()
+        }
+
+        repository.incrementAlarmId(handle)
+        repository.saveAlarm(handle, alarm)
+
+        if (pendingMessage != null) {
+            _events.value = Event(DashboardEvent.ScheduleAlarm(alarm))
+        }
+    }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/FirestoreDashboardRepository.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/FirestoreDashboardRepository.kt
@@ -1,0 +1,34 @@
+package com.example.rise.ui.dashboardNavigation.dashboard
+
+import com.example.rise.auth.UserSessionProvider
+import com.example.rise.models.Alarm
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+
+class FirestoreDashboardRepository(
+    private val firestore: FirebaseFirestore,
+    private val userSessionProvider: UserSessionProvider
+) : DashboardRepository {
+
+    override fun resolveUser(userId: String?): UserHandle {
+        val resolvedId = userId ?: userSessionProvider.currentUserId()
+        return UserHandle(resolvedId)
+    }
+
+    override fun buildAlarmQuery(handle: UserHandle): AlarmQuery {
+        val document = firestore.document("users/${handle.userId}")
+        return FirestoreAlarmQuery(document.collection("alarms"))
+    }
+
+    override fun incrementAlarmId(handle: UserHandle) {
+        firestore.document("users/${handle.userId}")
+            .update("id", FieldValue.increment(1))
+    }
+
+    override fun saveAlarm(handle: UserHandle, alarm: Alarm) {
+        firestore.document("users/${handle.userId}")
+            .collection("alarms")
+            .document(alarm.idTimeStamp.toString())
+            .set(alarm)
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountFragment.kt
@@ -12,7 +12,6 @@ import com.example.rise.databinding.FragmentMyAccountBinding
 import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInActivity
 import com.example.rise.util.FirestoreUtil
 import com.firebase.ui.auth.AuthUI
-import org.koin.android.ext.android.get
 
 class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
 
@@ -21,6 +20,8 @@ class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
     private var pictureJustChanged = false
     private var _binding: FragmentMyAccountBinding? = null
     private val binding get() = _binding!!
+
+    override val viewModelClass = MyAccountBaseViewModel::class
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -96,7 +97,4 @@ class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
         _binding = null
     }
 
-    override fun createViewModel() {
-        viewModel = get()
-    }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInActivity.kt
@@ -20,7 +20,6 @@ import com.firebase.ui.auth.ErrorCodes
 import com.firebase.ui.auth.IdpResponse
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.messaging.FirebaseMessaging
-import org.koin.android.ext.android.get
 
 class SignInActivity : BaseActivity<SignInViewModel>() {
 
@@ -32,6 +31,8 @@ class SignInActivity : BaseActivity<SignInViewModel>() {
             .build()
     )
     private lateinit var binding: ActivitySignInBinding
+
+    override val viewModelClass = SignInViewModel::class
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -91,7 +92,4 @@ class SignInActivity : BaseActivity<SignInViewModel>() {
         }
     }
 
-    override fun createViewModel() {
-        viewModel = get()
-    }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatRepository.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatRepository.kt
@@ -1,0 +1,15 @@
+package com.example.rise.ui.dashboardNavigation.people.chatActivity
+
+import com.example.rise.models.TextMessage
+import com.example.rise.models.User
+import com.google.firebase.firestore.ListenerRegistration
+
+data class ChatUser(val id: String, val user: User)
+
+interface ChatRepository {
+    fun fetchCurrentUser(onResult: (ChatUser) -> Unit)
+    fun getOrCreateChatChannel(otherUserId: String, onResult: (String) -> Unit)
+    fun listenForMessages(channelId: String, onMessages: (List<TextMessage>) -> Unit): ListenerRegistration
+    fun sendMessage(channelId: String, message: TextMessage)
+    fun removeListener(registration: ListenerRegistration)
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModel.kt
@@ -1,5 +1,96 @@
 package com.example.rise.ui.dashboardNavigation.people.chatActivity
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.example.rise.baseclasses.BaseViewModel
+import com.example.rise.models.TextMessage
+import com.example.rise.util.Event
+import com.google.firebase.firestore.ListenerRegistration
+import java.util.Calendar
 
-class ChatViewModel: BaseViewModel() {}
+class ChatViewModel(
+    private val repository: ChatRepository
+) : BaseViewModel() {
+
+    data class ChatUiState(
+        val messages: List<TextMessage> = emptyList(),
+        val shouldInitRecycler: Boolean = true
+    )
+
+    sealed class ChatEvent {
+        object ClearMessageInput : ChatEvent()
+        data class LaunchDelayedMessage(
+            val otherUserId: String,
+            val channelId: String,
+            val message: TextMessage
+        ) : ChatEvent()
+    }
+
+    private val _uiState = MutableLiveData(ChatUiState())
+    val uiState: LiveData<ChatUiState> = _uiState
+
+    private val _events = MutableLiveData<Event<ChatEvent>>()
+    val events: LiveData<Event<ChatEvent>> = _events
+
+    private var chatUser: ChatUser? = null
+    private var channelId: String? = null
+    private var otherUserId: String? = null
+    private var listenerRegistration: ListenerRegistration? = null
+    private var firstEmission = true
+
+    fun loadConversation(otherUserId: String) {
+        if (otherUserId == this.otherUserId && channelId != null) {
+            return
+        }
+        this.otherUserId = otherUserId
+        repository.fetchCurrentUser { currentUser ->
+            chatUser = currentUser
+            repository.getOrCreateChatChannel(otherUserId) { id ->
+                channelId = id
+                listenerRegistration?.let { repository.removeListener(it) }
+                firstEmission = true
+                listenerRegistration = repository.listenForMessages(id) { messages ->
+                    val state = ChatUiState(
+                        messages = messages,
+                        shouldInitRecycler = firstEmission
+                    )
+                    firstEmission = false
+                    _uiState.postValue(state)
+                }
+            }
+        }
+    }
+
+    fun sendMessage(text: String) {
+        val message = buildMessage(text) ?: return
+        val channel = channelId ?: return
+        repository.sendMessage(channel, message)
+        _events.value = Event(ChatEvent.ClearMessageInput)
+    }
+
+    fun scheduleMessage(text: String) {
+        val message = buildMessage(text) ?: return
+        val channel = channelId ?: return
+        val receiver = otherUserId ?: return
+        _events.value = Event(ChatEvent.LaunchDelayedMessage(receiver, channel, message))
+    }
+
+    private fun buildMessage(rawText: String): TextMessage? {
+        val trimmed = rawText.trim()
+        if (trimmed.isEmpty()) return null
+        val user = chatUser ?: return null
+        val receiver = otherUserId ?: return null
+        return TextMessage(
+            text = trimmed,
+            time = Calendar.getInstance().time,
+            senderId = user.id,
+            recipientId = receiver,
+            senderName = user.user.name
+        )
+    }
+
+    override fun onCleared() {
+        listenerRegistration?.let { repository.removeListener(it) }
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/FirestoreChatRepository.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/FirestoreChatRepository.kt
@@ -1,0 +1,35 @@
+package com.example.rise.ui.dashboardNavigation.people.chatActivity
+
+import com.example.rise.auth.UserSessionProvider
+import com.example.rise.models.TextMessage
+import com.example.rise.util.FirestoreUtil
+import com.google.firebase.firestore.ListenerRegistration
+
+class FirestoreChatRepository(
+    private val userSessionProvider: UserSessionProvider
+) : ChatRepository {
+
+    override fun fetchCurrentUser(onResult: (ChatUser) -> Unit) {
+        val userId = userSessionProvider.currentUserId()
+        FirestoreUtil.getCurrentUser { user ->
+            onResult(ChatUser(userId, user))
+        }
+    }
+
+    override fun getOrCreateChatChannel(otherUserId: String, onResult: (String) -> Unit) {
+        FirestoreUtil.getOrCreateChatChannel(otherUserId, onResult)
+    }
+
+    override fun listenForMessages(
+        channelId: String,
+        onMessages: (List<TextMessage>) -> Unit
+    ): ListenerRegistration = FirestoreUtil.addChatMessagesListener(channelId, onMessages)
+
+    override fun sendMessage(channelId: String, message: TextMessage) {
+        FirestoreUtil.sendMessage(message, channelId)
+    }
+
+    override fun removeListener(registration: ListenerRegistration) {
+        FirestoreUtil.removeListener(registration)
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/FirestorePeopleRepository.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/FirestorePeopleRepository.kt
@@ -1,0 +1,24 @@
+package com.example.rise.ui.dashboardNavigation.people.peopleFragment
+
+import com.example.rise.auth.UserSessionProvider
+import com.example.rise.util.FirestoreUtil
+import com.google.firebase.firestore.ListenerRegistration
+
+class FirestorePeopleRepository(
+    private val userSessionProvider: UserSessionProvider
+) : PeopleRepository {
+
+    override fun listenForPeople(onPeopleChanged: (List<PersonRecord>) -> Unit): ListenerRegistration {
+        return FirestoreUtil.addUsersListener { users ->
+            val currentUserId = userSessionProvider.currentUserId()
+            val records = users
+                .filterKeys { it != currentUserId }
+                .map { (id, user) -> PersonRecord(id, user) }
+            onPeopleChanged(records)
+        }
+    }
+
+    override fun removeListener(registration: ListenerRegistration) {
+        FirestoreUtil.removeListener(registration)
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleFragment.kt
@@ -11,22 +11,18 @@ import com.example.rise.databinding.FragmentPeopleBinding
 import com.example.rise.helpers.AppConstants
 import com.example.rise.item.PersonItem
 import com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatActivity
-import com.example.rise.util.FirestoreUtil
-import com.google.firebase.firestore.ListenerRegistration
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.GroupieViewHolder
-import com.xwray.groupie.Item
-import com.xwray.groupie.OnItemClickListener
 import com.xwray.groupie.Section
-import org.koin.android.ext.android.get
 
 class PeopleFragment : BaseFragment<PeopleViewModel>() {
 
-    private lateinit var userListenerRegistration: ListenerRegistration
-    private var shouldInitRecyclerView = true
-    private lateinit var peopleSection: Section
     private var _binding: FragmentPeopleBinding? = null
     private val binding get() = _binding!!
+
+    private var peopleSection: Section? = null
+
+    override val viewModelClass = PeopleViewModel::class
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -34,51 +30,54 @@ class PeopleFragment : BaseFragment<PeopleViewModel>() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentPeopleBinding.inflate(inflater, container, false)
-        userListenerRegistration = FirestoreUtil.addUsersListener(requireActivity(), this::updateRecyclerView)
+        setupRecyclerView()
+        observeViewModel()
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.startListening()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        FirestoreUtil.removeListener(userListenerRegistration)
-        shouldInitRecyclerView = true
+        viewModel.stopListening()
         _binding = null
+        peopleSection = null
     }
 
-    private fun updateRecyclerView(items: List<Item<*>>) {
-
-        fun init() {
-            binding.recyclerViewPeople.apply {
-                layoutManager = LinearLayoutManager(requireContext())
-                adapter = GroupAdapter<GroupieViewHolder>().apply {
-                    peopleSection = Section(items)
-                    add(peopleSection)
-                    setOnItemClickListener(onItemClick)
-                }
+    private fun setupRecyclerView() {
+        val adapter = GroupAdapter<GroupieViewHolder>()
+        peopleSection = Section(emptyList()).also(adapter::add)
+        adapter.setOnItemClickListener { item, _ ->
+            if (item is PersonItem) {
+                viewModel.onPersonSelected(PersonRecord(item.userId, item.person))
             }
-            shouldInitRecyclerView = false
         }
-
-        fun updateItems() = peopleSection.update(items)
-
-        if (shouldInitRecyclerView) {
-            init()
-        } else {
-            updateItems()
-        }
+        binding.recyclerViewPeople.layoutManager = LinearLayoutManager(requireContext())
+        binding.recyclerViewPeople.adapter = adapter
     }
 
-    private val onItemClick = OnItemClickListener { item, _ ->
-        if (item is PersonItem) {
-            val intent = Intent(context, ChatActivity::class.java).apply {
-                putExtra(AppConstants.USER_NAME, item.person.name)
-                putExtra(AppConstants.USER_ID, item.userId)
+    private fun observeViewModel() {
+        viewModel.people.observe(viewLifecycleOwner) { records ->
+            val items = records.map { PersonItem(it.user, it.userId, requireContext()) }
+            peopleSection?.update(items)
+        }
+
+        viewModel.events.observe(viewLifecycleOwner) { event ->
+            when (val content = event.getContentIfNotHandled()) {
+                is PeopleViewModel.PeopleEvent.OpenChat -> openChat(content)
+                null -> Unit
             }
-            startActivity(intent)
         }
     }
 
-    override fun createViewModel() {
-        viewModel = get()
+    private fun openChat(event: PeopleViewModel.PeopleEvent.OpenChat) {
+        val intent = Intent(context, ChatActivity::class.java).apply {
+            putExtra(AppConstants.USER_NAME, event.userName)
+            putExtra(AppConstants.USER_ID, event.userId)
+        }
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleRepository.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleRepository.kt
@@ -1,0 +1,11 @@
+package com.example.rise.ui.dashboardNavigation.people.peopleFragment
+
+import com.example.rise.models.User
+import com.google.firebase.firestore.ListenerRegistration
+
+data class PersonRecord(val userId: String, val user: User)
+
+interface PeopleRepository {
+    fun listenForPeople(onPeopleChanged: (List<PersonRecord>) -> Unit): ListenerRegistration
+    fun removeListener(registration: ListenerRegistration)
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModel.kt
@@ -1,5 +1,45 @@
 package com.example.rise.ui.dashboardNavigation.people.peopleFragment
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.example.rise.baseclasses.BaseViewModel
+import com.example.rise.util.Event
+import com.google.firebase.firestore.ListenerRegistration
 
-class PeopleViewModel: BaseViewModel() {}
+class PeopleViewModel(
+    private val repository: PeopleRepository
+) : BaseViewModel() {
+
+    sealed class PeopleEvent {
+        data class OpenChat(val userId: String, val userName: String) : PeopleEvent()
+    }
+
+    private val _people = MutableLiveData<List<PersonRecord>>(emptyList())
+    val people: LiveData<List<PersonRecord>> = _people
+
+    private val _events = MutableLiveData<Event<PeopleEvent>>()
+    val events: LiveData<Event<PeopleEvent>> = _events
+
+    private var listenerRegistration: ListenerRegistration? = null
+
+    fun startListening() {
+        if (listenerRegistration != null) return
+        listenerRegistration = repository.listenForPeople { records ->
+            _people.postValue(records)
+        }
+    }
+
+    fun stopListening() {
+        listenerRegistration?.let { repository.removeListener(it) }
+        listenerRegistration = null
+    }
+
+    fun onPersonSelected(record: PersonRecord) {
+        _events.value = Event(PeopleEvent.OpenChat(record.userId, record.user.name))
+    }
+
+    override fun onCleared() {
+        stopListening()
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/mainActivity/MainActivityViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/mainActivity/MainActivityViewModel.kt
@@ -1,7 +1,32 @@
 package com.example.rise.ui.mainActivity
 
+import android.content.Intent
+import com.example.rise.auth.AuthStateProvider
+import com.example.rise.auth.SignInIntentProvider
 import com.example.rise.baseclasses.BaseViewModel
 
-class MainActivityViewModel() : BaseViewModel(){
-    var mSignIn : Boolean = false
+class MainActivityViewModel(
+    private val authStateProvider: AuthStateProvider,
+    private val signInIntentProvider: SignInIntentProvider
+) : BaseViewModel() {
+
+    private var signingIn: Boolean = false
+
+    fun requestSignInIfNeeded(): Intent? {
+        if (!signingIn && !authStateProvider.isUserSignedIn()) {
+            signingIn = true
+            return signInIntentProvider.createSignInIntent()
+        }
+        return null
+    }
+
+    fun requestRetrySignIn(isResultSuccessful: Boolean): Intent? {
+        signingIn = false
+        if (!isResultSuccessful && !authStateProvider.isUserSignedIn()) {
+            signingIn = true
+            return signInIntentProvider.createSignInIntent()
+        }
+        return null
+    }
+
 }

--- a/app/src/main/java/com/example/rise/util/Event.kt
+++ b/app/src/main/java/com/example/rise/util/Event.kt
@@ -1,0 +1,17 @@
+package com.example.rise.util
+
+open class Event<out T>(private val content: T) {
+
+    private var hasBeenHandled = false
+
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    fun peekContent(): T = content
+}

--- a/app/src/main/java/com/example/rise/util/FirestoreUtil.kt
+++ b/app/src/main/java/com/example/rise/util/FirestoreUtil.kt
@@ -1,8 +1,5 @@
 package com.example.rise.util
 
-import android.content.Context
-import com.example.rise.item.PersonItem
-import com.example.rise.item.TextMessageItem
 import com.example.rise.models.ChatChannel
 import com.example.rise.models.Message
 import com.example.rise.models.MessageType
@@ -12,7 +9,6 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
-import com.xwray.groupie.Item
 import timber.log.Timber
 
 object FirestoreUtil {
@@ -61,7 +57,7 @@ object FirestoreUtil {
             }
     }
 
-    fun addUsersListener(context: Context, onListen: (List<Item<*>>) -> Unit): ListenerRegistration {
+    fun addUsersListener(onListen: (Map<String, User>) -> Unit): ListenerRegistration {
         return firestoreInstance.collection("users")
             .addSnapshotListener { querySnapshot, firebaseFirestoreException ->
                 if (firebaseFirestoreException != null) {
@@ -70,13 +66,13 @@ object FirestoreUtil {
                     return@addSnapshotListener
                 }
 
-                val items = mutableListOf<Item<*>>()
+                val users = mutableMapOf<String, User>()
                 querySnapshot!!.documents.forEach {
                     if (it.id != FirebaseAuth.getInstance().currentUser?.uid) {
-                        items.add(PersonItem(it.toObject(User::class.java)!!, it.id, context))
+                        users[it.id] = it.toObject(User::class.java)!!
                     }
                 }
-                onListen(items)
+                onListen(users)
             }
     }
 
@@ -111,8 +107,7 @@ object FirestoreUtil {
 
     fun addChatMessagesListener(
         channelId: String,
-        context: Context,
-        onListen: (List<Item<*>>) -> Unit
+        onListen: (List<TextMessage>) -> Unit
     ): ListenerRegistration {
         return chatChannelsCollectionRef.document(channelId).collection("messages")
             .orderBy("time")
@@ -122,10 +117,10 @@ object FirestoreUtil {
                     return@addSnapshotListener
                 }
 
-                val items = mutableListOf<Item<*>>()
+                val items = mutableListOf<TextMessage>()
                 querySnapshot!!.documents.forEach {
                     if (it["type"] == MessageType.TEXT) {
-                        items.add(TextMessageItem(it.toObject(TextMessage::class.java)!!))
+                        items.add(it.toObject(TextMessage::class.java)!!)
                     } else {
                         // items.add(ImageMessageItem(it.toObject(ImageMessage::class.java)!!, context))
                     }

--- a/app/src/test/java/com/example/rise/ui/SplashActivityViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/SplashActivityViewModelTest.kt
@@ -1,0 +1,43 @@
+package com.example.rise.ui
+
+import com.example.rise.auth.AuthStateProvider
+import com.example.rise.ui.SplashActivityViewModel.Destination
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class SplashActivityViewModelTest {
+
+    private lateinit var viewModel: SplashActivityViewModel
+    private lateinit var authStateProvider: FakeAuthStateProvider
+
+    @Before
+    fun setUp() {
+        authStateProvider = FakeAuthStateProvider()
+        viewModel = SplashActivityViewModel(authStateProvider)
+    }
+
+    @Test
+    fun `returns sign in destination when user is not authenticated`() {
+        authStateProvider.isSignedIn = false
+
+        val destination = viewModel.resolveDestination()
+
+        assertEquals(Destination.SIGN_IN, destination)
+    }
+
+    @Test
+    fun `returns main destination when user is authenticated`() {
+        authStateProvider.isSignedIn = true
+
+        val destination = viewModel.resolveDestination()
+
+        assertEquals(Destination.MAIN, destination)
+    }
+
+    private class FakeAuthStateProvider : AuthStateProvider {
+        var isSignedIn: Boolean = false
+
+        override fun isUserSignedIn(): Boolean = isSignedIn
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModelTest.kt
@@ -1,0 +1,133 @@
+package com.example.rise.ui.dashboardNavigation.dashboard
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.example.rise.auth.UserSessionProvider
+import com.example.rise.models.Alarm
+import com.example.rise.models.TextMessage
+import com.google.firebase.firestore.Query
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class DashboardViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var repository: FakeDashboardRepository
+    private lateinit var sessionProvider: FakeSessionProvider
+    private lateinit var viewModel: DashboardViewModel
+
+    @Before
+    fun setUp() {
+        repository = FakeDashboardRepository()
+        sessionProvider = FakeSessionProvider()
+        viewModel = DashboardViewModel(repository, sessionProvider)
+    }
+
+    @Test
+    fun `initialize resolves user based on navigation source`() {
+        viewModel.initialize("other-id", null, null, launchedFromBottomNavigation = false)
+
+        assertEquals(listOf("other-id"), repository.resolvedUserIds)
+        assertEquals("other-id", viewModel.otherUserId.value)
+        assertTrue(repository.buildQueryInvoked)
+
+        repository.clear()
+
+        viewModel.initialize("other-id", null, null, launchedFromBottomNavigation = true)
+
+        assertEquals(listOf(null), repository.resolvedUserIds)
+        assertNull(viewModel.otherUserId.value)
+    }
+
+    @Test
+    fun `createAlarm persists data and emits schedule when message present`() {
+        val message = TextMessage("text", java.util.Date(), "sender", "receiver", "sender")
+        viewModel.initialize(null, "channel", message, launchedFromBottomNavigation = true)
+
+        var scheduledAlarm: Alarm? = null
+        viewModel.events.observeForever { event ->
+            val content = event.getContentIfNotHandled()
+            if (content is DashboardViewModel.DashboardEvent.ScheduleAlarm) {
+                scheduledAlarm = content.alarm
+            }
+        }
+
+        viewModel.createAlarm(1234L)
+
+        assertTrue(repository.incrementCalled)
+        assertEquals(1, repository.savedAlarms.size)
+        val saved = repository.savedAlarms.first()
+        assertEquals("session-user", saved.first.userId)
+        assertEquals("channel", saved.second.chatChannel)
+        assertSame(message, saved.second.messsage)
+        assertEquals(sessionProvider.displayName, saved.second.userName)
+
+        assertEquals(saved.second, scheduledAlarm)
+    }
+
+    @Test
+    fun `createAlarm does not emit schedule when message missing`() {
+        viewModel.initialize(null, "channel", null, launchedFromBottomNavigation = true)
+
+        var scheduled = false
+        viewModel.events.observeForever { event ->
+            scheduled = scheduled || event.getContentIfNotHandled() is DashboardViewModel.DashboardEvent.ScheduleAlarm
+        }
+
+        viewModel.createAlarm(5000L)
+
+        assertTrue(repository.incrementCalled)
+        assertTrue(repository.savedAlarms.isNotEmpty())
+        assertTrue(!scheduled)
+    }
+
+    private class FakeDashboardRepository : DashboardRepository {
+        val savedAlarms = mutableListOf<Pair<UserHandle, Alarm>>()
+        val resolvedUserIds = mutableListOf<String?>()
+        var buildQueryInvoked = false
+        var incrementCalled = false
+
+        fun clear() {
+            savedAlarms.clear()
+            resolvedUserIds.clear()
+            buildQueryInvoked = false
+            incrementCalled = false
+        }
+
+        override fun resolveUser(userId: String?): UserHandle {
+            resolvedUserIds.add(userId)
+            return UserHandle(userId ?: "session-user")
+        }
+
+        override fun buildAlarmQuery(handle: UserHandle): AlarmQuery {
+            buildQueryInvoked = true
+            return object : AlarmQuery {
+                override fun unwrap(): Query {
+                    throw UnsupportedOperationException()
+                }
+            }
+        }
+
+        override fun incrementAlarmId(handle: UserHandle) {
+            incrementCalled = true
+        }
+
+        override fun saveAlarm(handle: UserHandle, alarm: Alarm) {
+            savedAlarms += handle to alarm
+        }
+    }
+
+    private class FakeSessionProvider : UserSessionProvider {
+        val displayName = "Session User"
+
+        override fun currentUserId(): String = "session-user"
+
+        override fun currentUserName(): String = displayName
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModelTest.kt
@@ -1,0 +1,143 @@
+package com.example.rise.ui.dashboardNavigation.people.chatActivity
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import com.example.rise.models.TextMessage
+import com.example.rise.models.User
+import com.google.firebase.firestore.ListenerRegistration
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.Date
+
+class ChatViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var repository: FakeChatRepository
+    private lateinit var viewModel: ChatViewModel
+
+    @Before
+    fun setUp() {
+        repository = FakeChatRepository()
+        viewModel = ChatViewModel(repository)
+    }
+
+    @Test
+    fun `loadConversation emits messages with initialization flag`() {
+        val observer = Observer<ChatViewModel.ChatUiState> { }
+        viewModel.uiState.observeForever(observer)
+
+        viewModel.loadConversation("other-user")
+
+        val firstMessage = sampleMessage("first")
+        repository.emitMessages(listOf(firstMessage))
+
+        assertEquals(listOf(firstMessage), viewModel.uiState.value?.messages)
+        assertTrue(viewModel.uiState.value?.shouldInitRecycler == true)
+
+        val secondMessage = sampleMessage("second")
+        repository.emitMessages(listOf(secondMessage))
+
+        assertEquals(listOf(secondMessage), viewModel.uiState.value?.messages)
+        assertFalse(viewModel.uiState.value?.shouldInitRecycler ?: true)
+
+        viewModel.uiState.removeObserver(observer)
+    }
+
+    @Test
+    fun `sendMessage delegates to repository and clears input`() {
+        viewModel.loadConversation("other-user")
+        repository.emitMessages(emptyList())
+
+        val events = mutableListOf<ChatViewModel.ChatEvent>()
+        viewModel.events.observeForever { event ->
+            event.getContentIfNotHandled()?.let { events.add(it) }
+        }
+
+        viewModel.sendMessage(" hello ")
+
+        val sentMessage = repository.lastSentMessage
+        assertNotNull(sentMessage)
+        assertEquals("hello", sentMessage?.text)
+        assertEquals(repository.currentUser.id, sentMessage?.senderId)
+        assertEquals("other-user", sentMessage?.recipientId)
+
+        assertTrue(events.lastOrNull() is ChatViewModel.ChatEvent.ClearMessageInput)
+    }
+
+    @Test
+    fun `scheduleMessage emits navigation event`() {
+        viewModel.loadConversation("other-user")
+        repository.emitMessages(emptyList())
+
+        var scheduledEvent: ChatViewModel.ChatEvent.LaunchDelayedMessage? = null
+        viewModel.events.observeForever { event ->
+            val content = event.getContentIfNotHandled()
+            if (content is ChatViewModel.ChatEvent.LaunchDelayedMessage) {
+                scheduledEvent = content
+            }
+        }
+
+        viewModel.scheduleMessage("Reminder")
+
+        val event = scheduledEvent
+        assertNotNull(event)
+        assertEquals("other-user", event?.otherUserId)
+        assertEquals(repository.channelId, event?.channelId)
+        assertEquals("Reminder", event?.message?.text)
+    }
+
+    private fun sampleMessage(text: String) = TextMessage(
+        text = text,
+        time = Date(),
+        senderId = "sender",
+        recipientId = "recipient",
+        senderName = "Sender"
+    )
+
+    private class FakeChatRepository : ChatRepository {
+        val currentUser = ChatUser(
+            "sender-id",
+            User(name = "Sender", bio = "", profilePicturePath = null, registrationTokens = mutableListOf())
+        )
+        var channelId: String = "channel-id"
+        var lastSentMessage: TextMessage? = null
+        private var listener: ((List<TextMessage>) -> Unit)? = null
+
+        override fun fetchCurrentUser(onResult: (ChatUser) -> Unit) {
+            onResult(currentUser)
+        }
+
+        override fun getOrCreateChatChannel(otherUserId: String, onResult: (String) -> Unit) {
+            onResult(channelId)
+        }
+
+        override fun listenForMessages(
+            channelId: String,
+            onMessages: (List<TextMessage>) -> Unit
+        ): ListenerRegistration {
+            listener = onMessages
+            return object : ListenerRegistration {
+                override fun remove() {}
+            }
+        }
+
+        override fun sendMessage(channelId: String, message: TextMessage) {
+            this.lastSentMessage = message
+        }
+
+        override fun removeListener(registration: ListenerRegistration) {
+            registration.remove()
+        }
+
+        fun emitMessages(messages: List<TextMessage>) {
+            listener?.invoke(messages)
+        }
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModelTest.kt
@@ -1,0 +1,87 @@
+package com.example.rise.ui.dashboardNavigation.people.peopleFragment
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.example.rise.models.User
+import com.google.firebase.firestore.ListenerRegistration
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class PeopleViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var repository: FakePeopleRepository
+    private lateinit var viewModel: PeopleViewModel
+
+    @Before
+    fun setUp() {
+        repository = FakePeopleRepository()
+        viewModel = PeopleViewModel(repository)
+    }
+
+    @Test
+    fun `startListening updates people list`() {
+        viewModel.people.observeForever { }
+
+        viewModel.startListening()
+
+        val person = PersonRecord("id", User("Alice", "Bio", null, mutableListOf()))
+        repository.emit(listOf(person))
+
+        assertEquals(listOf(person), viewModel.people.value)
+    }
+
+    @Test
+    fun `stopListening removes listener`() {
+        viewModel.startListening()
+        viewModel.stopListening()
+
+        assertTrue(repository.listenerRemoved)
+    }
+
+    @Test
+    fun `onPersonSelected emits navigation event`() {
+        viewModel.startListening()
+
+        var event: PeopleViewModel.PeopleEvent.OpenChat? = null
+        viewModel.events.observeForever { emitted ->
+            val content = emitted.getContentIfNotHandled()
+            if (content is PeopleViewModel.PeopleEvent.OpenChat) {
+                event = content
+            }
+        }
+
+        val record = PersonRecord("id", User("Bob", "Bio", null, mutableListOf()))
+        viewModel.onPersonSelected(record)
+
+        val emitted = event
+        assertEquals("id", emitted?.userId)
+        assertEquals("Bob", emitted?.userName)
+    }
+
+    private class FakePeopleRepository : PeopleRepository {
+        private var listener: ((List<PersonRecord>) -> Unit)? = null
+        var listenerRemoved = false
+
+        override fun listenForPeople(onPeopleChanged: (List<PersonRecord>) -> Unit): ListenerRegistration {
+            listener = onPeopleChanged
+            return object : ListenerRegistration {
+                override fun remove() {
+                    listenerRemoved = true
+                }
+            }
+        }
+
+        override fun removeListener(registration: ListenerRegistration) {
+            registration.remove()
+        }
+
+        fun emit(records: List<PersonRecord>) {
+            listener?.invoke(records)
+        }
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/mainActivity/MainActivityViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/mainActivity/MainActivityViewModelTest.kt
@@ -1,0 +1,77 @@
+package com.example.rise.ui.mainActivity
+
+import android.content.Intent
+import com.example.rise.auth.AuthStateProvider
+import com.example.rise.auth.SignInIntentProvider
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+class MainActivityViewModelTest {
+
+    private lateinit var viewModel: MainActivityViewModel
+    private lateinit var authStateProvider: FakeAuthStateProvider
+    private lateinit var signInIntentProvider: FakeSignInIntentProvider
+
+    @Before
+    fun setUp() {
+        authStateProvider = FakeAuthStateProvider()
+        signInIntentProvider = FakeSignInIntentProvider()
+        viewModel = MainActivityViewModel(authStateProvider, signInIntentProvider)
+    }
+
+    @Test
+    fun `requests sign in intent when user is not signed in and no flow in progress`() {
+        authStateProvider.isSignedIn = false
+
+        val intent = viewModel.requestSignInIfNeeded()
+
+        assertSame(signInIntentProvider.intent, intent)
+    }
+
+    @Test
+    fun `does not request sign in twice while already in progress`() {
+        authStateProvider.isSignedIn = false
+
+        viewModel.requestSignInIfNeeded()
+
+        val intent = viewModel.requestSignInIfNeeded()
+
+        assertNull(intent)
+    }
+
+    @Test
+    fun `requests retry intent when sign in fails and user still signed out`() {
+        authStateProvider.isSignedIn = false
+
+        viewModel.requestSignInIfNeeded()
+
+        val intent = viewModel.requestRetrySignIn(isResultSuccessful = false)
+
+        assertSame(signInIntentProvider.intent, intent)
+    }
+
+    @Test
+    fun `does not request retry when sign in succeeds`() {
+        authStateProvider.isSignedIn = true
+
+        viewModel.requestSignInIfNeeded()
+
+        val intent = viewModel.requestRetrySignIn(isResultSuccessful = true)
+
+        assertNull(intent)
+    }
+
+    private class FakeAuthStateProvider : AuthStateProvider {
+        var isSignedIn: Boolean = false
+
+        override fun isUserSignedIn(): Boolean = isSignedIn
+    }
+
+    private class FakeSignInIntentProvider : SignInIntentProvider {
+        val intent: Intent = Intent("test")
+
+        override fun createSignInIntent(): Intent = intent
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
-        classpath 'com.google.gms:google-services:4.4.1'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
+        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.google.gms:google-services:4.4.3'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,6 +24,7 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,6 @@
 
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.daemon=true
+org.gradle.caching=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- move chat, people, and dashboard UI classes to observe view-model state rather than invoking Firestore utilities directly
- introduce repository abstractions plus a user session provider so the new view-model logic can be supplied through Koin
- add unit tests that exercise the chat, people, and dashboard view-model behaviours with fakes

## Testing
- not run (gradle assembleDebug repeatedly stalled while downloading Android dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68da8066ba48832280f19f7761e4703c