### PR TITLE
Refactor screens to use view models with repository layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 /.idea/migrations.xml
 /.idea/studiobot.xml
 /.idea/runConfigurations.xml
+gradle/wrapper/gradle-wrapper.jar
+android-commandlinetools.zip

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.google.gms.google-services'
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'kotlin-parcelize'
 
 android {
@@ -54,6 +54,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.fragment:fragment-ktx:1.6.2'
+    implementation 'androidx.activity:activity-ktx:1.8.2'
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.7.6'
     implementation 'androidx.navigation:navigation-ui-ktx:2.7.6'
@@ -73,11 +74,19 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:20.7.0'
 
     implementation 'com.github.bumptech.glide:glide:4.16.0'
-    kapt 'com.github.bumptech.glide:compiler:4.16.0'
-    kapt 'com.github.bumptech.glide:annotations:4.16.0'
+    ksp 'com.github.bumptech.glide:ksp:4.16.0'
     implementation 'com.jakewharton.timber:timber:5.0.1'
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2"
     implementation "androidx.lifecycle:lifecycle-common-java8:2.6.2"
+
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.8.1'
+    testImplementation 'app.cash.turbine:turbine:1.0.0'
+    
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1'
+    testImplementation 'io.mockk:mockk:1.13.10'
 
     implementation 'com.github.lisawray.groupie:groupie:2.10.1'
     implementation 'com.github.lisawray.groupie:groupie-viewbinding:2.10.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.rise">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />

--- a/app/src/main/java/com/example/rise/App.kt
+++ b/app/src/main/java/com/example/rise/App.kt
@@ -9,6 +9,8 @@ import com.example.rise.data.chat.ChatRepository
 import com.example.rise.data.chat.FirestoreChatRepository
 import com.example.rise.data.dashboard.AlarmRepository
 import com.example.rise.data.dashboard.FirestoreAlarmRepository
+import com.example.rise.data.myaccount.FirebaseMyAccountRepository
+import com.example.rise.data.myaccount.MyAccountRepository
 import com.example.rise.data.people.FirestorePeopleRepository
 import com.example.rise.data.people.PeopleRepository
 import com.example.rise.ui.SplashActivityViewModel
@@ -42,9 +44,10 @@ class App: Application() {
         single<ChatRepository> { FirestoreChatRepository(get(), get()) }
         single<PeopleRepository> { FirestorePeopleRepository(get(), get()) }
         single<AlarmRepository> { FirestoreAlarmRepository(get()) }
+        single<MyAccountRepository> { FirebaseMyAccountRepository(get(), get(), get(), androidContext()) }
 
         viewModel { SplashActivityViewModel(get()) }
-        viewModel { MyAccountBaseViewModel() }
+        viewModel { MyAccountBaseViewModel(get()) }
         viewModel { DashboardViewModel(get(), get()) }
         viewModel { ChatViewModel(get()) }
         viewModel { PeopleViewModel(get()) }

--- a/app/src/main/java/com/example/rise/App.kt
+++ b/app/src/main/java/com/example/rise/App.kt
@@ -3,8 +3,10 @@ package com.example.rise
 import android.app.Application
 import com.example.rise.data.auth.AuthStateProvider
 import com.example.rise.data.auth.FirebaseAuthStateProvider
+import com.example.rise.data.auth.FirebaseSignInRepository
 import com.example.rise.data.auth.FirebaseUiSignInIntentProvider
 import com.example.rise.data.auth.SignInIntentProvider
+import com.example.rise.data.auth.SignInRepository
 import com.example.rise.data.chat.ChatRepository
 import com.example.rise.data.chat.FirestoreChatRepository
 import com.example.rise.data.dashboard.AlarmRepository
@@ -24,6 +26,7 @@ import com.firebase.ui.auth.AuthUI
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.messaging.FirebaseMessaging
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -37,9 +40,11 @@ class App: Application() {
         single { FirebaseAuth.getInstance() }
         single { FirebaseFirestore.getInstance() }
         single { AuthUI.getInstance() }
+        single { FirebaseMessaging.getInstance() }
 
         single<AuthStateProvider> { FirebaseAuthStateProvider(get()) }
         single<SignInIntentProvider> { FirebaseUiSignInIntentProvider(get()) }
+        single<SignInRepository> { FirebaseSignInRepository(get()) }
 
         single<ChatRepository> { FirestoreChatRepository(get(), get()) }
         single<PeopleRepository> { FirestorePeopleRepository(get(), get()) }
@@ -52,7 +57,7 @@ class App: Application() {
         viewModel { ChatViewModel(get()) }
         viewModel { PeopleViewModel(get()) }
         viewModel { MainActivityViewModel(get(), get()) }
-        viewModel { SignInViewModel() }
+        viewModel { SignInViewModel(get(), get()) }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/example/rise/App.kt
+++ b/app/src/main/java/com/example/rise/App.kt
@@ -1,6 +1,8 @@
 package com.example.rise
 
 import android.app.Application
+import com.example.rise.data.alarm.ConfigReminderPreferences
+import com.example.rise.data.alarm.ReminderPreferences
 import com.example.rise.data.auth.AuthStateProvider
 import com.example.rise.data.auth.FirebaseAuthStateProvider
 import com.example.rise.data.auth.FirebaseSignInRepository
@@ -15,9 +17,11 @@ import com.example.rise.data.myaccount.FirebaseMyAccountRepository
 import com.example.rise.data.myaccount.MyAccountRepository
 import com.example.rise.data.people.FirestorePeopleRepository
 import com.example.rise.data.people.PeopleRepository
+import com.example.rise.helpers.Config
 import com.example.rise.ui.SplashActivityViewModel
+import com.example.rise.ui.alarm.ReminderViewModel
 import com.example.rise.ui.dashboardNavigation.dashboard.DashboardViewModel
-import com.example.rise.ui.dashboardNavigation.myAccount.MyAccountBaseViewModel
+import com.example.rise.ui.dashboardNavigation.myAccount.MyAccountViewModel
 import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInViewModel
 import com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatViewModel
 import com.example.rise.ui.dashboardNavigation.people.peopleFragment.PeopleViewModel
@@ -41,10 +45,12 @@ class App: Application() {
         single { FirebaseFirestore.getInstance() }
         single { AuthUI.getInstance() }
         single { FirebaseMessaging.getInstance() }
+        single { Config.newInstance(androidContext()) }
 
         single<AuthStateProvider> { FirebaseAuthStateProvider(get()) }
         single<SignInIntentProvider> { FirebaseUiSignInIntentProvider(get()) }
         single<SignInRepository> { FirebaseSignInRepository(get()) }
+        single<ReminderPreferences> { ConfigReminderPreferences(get()) }
 
         single<ChatRepository> { FirestoreChatRepository(get(), get()) }
         single<PeopleRepository> { FirestorePeopleRepository(get(), get()) }
@@ -52,7 +58,8 @@ class App: Application() {
         single<MyAccountRepository> { FirebaseMyAccountRepository(get(), get(), get(), androidContext()) }
 
         viewModel { SplashActivityViewModel(get()) }
-        viewModel { MyAccountBaseViewModel(get()) }
+        viewModel { ReminderViewModel(get()) }
+        viewModel { MyAccountViewModel(get()) }
         viewModel { DashboardViewModel(get(), get()) }
         viewModel { ChatViewModel(get()) }
         viewModel { PeopleViewModel(get()) }

--- a/app/src/main/java/com/example/rise/App.kt
+++ b/app/src/main/java/com/example/rise/App.kt
@@ -14,6 +14,7 @@ import com.example.rise.data.people.PeopleRepository
 import com.example.rise.ui.SplashActivityViewModel
 import com.example.rise.ui.dashboardNavigation.dashboard.DashboardViewModel
 import com.example.rise.ui.dashboardNavigation.myAccount.MyAccountBaseViewModel
+import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInViewModel
 import com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatViewModel
 import com.example.rise.ui.dashboardNavigation.people.peopleFragment.PeopleViewModel
 import com.example.rise.ui.mainActivity.MainActivityViewModel
@@ -48,6 +49,7 @@ class App: Application() {
         viewModel { ChatViewModel(get()) }
         viewModel { PeopleViewModel(get()) }
         viewModel { MainActivityViewModel(get(), get()) }
+        viewModel { SignInViewModel() }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/example/rise/App.kt
+++ b/app/src/main/java/com/example/rise/App.kt
@@ -1,15 +1,28 @@
 package com.example.rise
 
 import android.app.Application
-import android.provider.Contacts
+import com.example.rise.data.auth.AuthStateProvider
+import com.example.rise.data.auth.FirebaseAuthStateProvider
+import com.example.rise.data.auth.FirebaseUiSignInIntentProvider
+import com.example.rise.data.auth.SignInIntentProvider
+import com.example.rise.data.chat.ChatRepository
+import com.example.rise.data.chat.FirestoreChatRepository
+import com.example.rise.data.dashboard.AlarmRepository
+import com.example.rise.data.dashboard.FirestoreAlarmRepository
+import com.example.rise.data.people.FirestorePeopleRepository
+import com.example.rise.data.people.PeopleRepository
 import com.example.rise.ui.SplashActivityViewModel
 import com.example.rise.ui.dashboardNavigation.dashboard.DashboardViewModel
 import com.example.rise.ui.dashboardNavigation.myAccount.MyAccountBaseViewModel
 import com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatViewModel
 import com.example.rise.ui.dashboardNavigation.people.peopleFragment.PeopleViewModel
 import com.example.rise.ui.mainActivity.MainActivityViewModel
+import com.firebase.ui.auth.AuthUI
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
 import timber.log.Timber
@@ -17,12 +30,23 @@ import timber.log.Timber
 class App: Application() {
 
     val appModule = module {
-        factory { SplashActivityViewModel() }
-        factory { MyAccountBaseViewModel() }
-        factory { DashboardViewModel() }
-        factory { ChatViewModel() }
-        factory { PeopleViewModel() }
-        factory { MainActivityViewModel() }
+        single { FirebaseAuth.getInstance() }
+        single { FirebaseFirestore.getInstance() }
+        single { AuthUI.getInstance() }
+
+        single<AuthStateProvider> { FirebaseAuthStateProvider(get()) }
+        single<SignInIntentProvider> { FirebaseUiSignInIntentProvider(get()) }
+
+        single<ChatRepository> { FirestoreChatRepository(get(), get()) }
+        single<PeopleRepository> { FirestorePeopleRepository(get(), get()) }
+        single<AlarmRepository> { FirestoreAlarmRepository(get()) }
+
+        viewModel { SplashActivityViewModel(get()) }
+        viewModel { MyAccountBaseViewModel() }
+        viewModel { DashboardViewModel(get(), get()) }
+        viewModel { ChatViewModel(get()) }
+        viewModel { PeopleViewModel(get()) }
+        viewModel { MainActivityViewModel(get(), get()) }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/example/rise/App.kt
+++ b/app/src/main/java/com/example/rise/App.kt
@@ -18,6 +18,7 @@ import com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatViewModel
 import com.example.rise.ui.dashboardNavigation.people.peopleFragment.PeopleViewModel
 import com.example.rise.ui.mainActivity.MainActivityViewModel
 import com.firebase.ui.auth.AuthUI
+import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import org.koin.android.ext.koin.androidContext
@@ -52,6 +53,8 @@ class App: Application() {
     override fun onCreate() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
+
+        FirebaseApp.initializeApp(this)
 
         startKoin {
             //Koin android logger

--- a/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
@@ -2,7 +2,7 @@ package com.example.rise.baseclasses
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.ViewModel
+import kotlin.LazyThreadSafetyMode
 import kotlin.reflect.KClass
 import org.koin.androidx.viewmodel.ext.android.viewModelForClass
 import org.koin.core.parameter.ParametersDefinition
@@ -14,18 +14,16 @@ abstract class BaseActivity<VM : BaseViewModel> : AppCompatActivity() {
     protected open val viewModelParameters: ParametersDefinition? = null
     protected open val viewModelQualifier: Qualifier? = null
 
-    private val viewModelDelegate: Lazy<out ViewModel> = viewModelForClass(
-        clazz = viewModelClass,
-        qualifier = viewModelQualifier,
-        parameters = viewModelParameters,
-    )
-
-    @Suppress("UNCHECKED_CAST")
-    protected val viewModel: VM
-        get() = viewModelDelegate.value as VM
+    protected val viewModel: VM by lazy(LazyThreadSafetyMode.NONE) {
+        viewModelForClass(
+            clazz = viewModelClass,
+            qualifier = viewModelQualifier,
+            parameters = viewModelParameters,
+        ).value
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModelDelegate.value
+        viewModel
     }
 }

--- a/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
@@ -2,9 +2,11 @@ package com.example.rise.baseclasses
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import kotlin.LazyThreadSafetyMode
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelLazy
 import kotlin.reflect.KClass
-import org.koin.androidx.viewmodel.ext.android.viewModelForClass
+import org.koin.android.ext.android.getKoin
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 
@@ -14,13 +16,33 @@ abstract class BaseActivity<VM : BaseViewModel> : AppCompatActivity() {
     protected open val viewModelParameters: ParametersDefinition? = null
     protected open val viewModelQualifier: Qualifier? = null
 
-    protected val viewModel: VM by lazy(LazyThreadSafetyMode.NONE) {
-        viewModelForClass(
-            clazz = viewModelClass,
-            qualifier = viewModelQualifier,
-            parameters = viewModelParameters,
-        ).value
-    }
+    protected val viewModel: VM by viewModelDelegate()
+
+    protected open fun provideViewModelFactory(): ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                if (!modelClass.isAssignableFrom(viewModelClass.java)) {
+                    throw IllegalArgumentException("Unknown ViewModel class: ${'$'}modelClass")
+                }
+
+                val viewModel: VM = getKoin().get(
+                    clazz = viewModelClass,
+                    qualifier = viewModelQualifier,
+                    parameters = viewModelParameters,
+                )
+
+                @Suppress("UNCHECKED_CAST")
+                return viewModel as T
+            }
+        }
+
+    private fun viewModelDelegate(): ViewModelLazy<VM> =
+        ViewModelLazy(
+            viewModelClass,
+            { viewModelStore },
+            { provideViewModelFactory() },
+            { defaultViewModelCreationExtras },
+        )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
@@ -1,51 +1,5 @@
 package com.example.rise.baseclasses
 
-import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelLazy
-import kotlin.reflect.KClass
-import org.koin.android.ext.android.getKoin
-import org.koin.core.parameter.ParametersDefinition
-import org.koin.core.qualifier.Qualifier
 
-abstract class BaseActivity<VM : BaseViewModel> : AppCompatActivity() {
-
-    protected abstract val viewModelClass: KClass<VM>
-    protected open val viewModelParameters: ParametersDefinition? = null
-    protected open val viewModelQualifier: Qualifier? = null
-
-    protected val viewModel: VM by viewModelDelegate()
-
-    protected open fun provideViewModelFactory(): ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                if (!modelClass.isAssignableFrom(viewModelClass.java)) {
-                    throw IllegalArgumentException("Unknown ViewModel class: ${'$'}modelClass")
-                }
-
-                val viewModel: VM = getKoin().get(
-                    clazz = viewModelClass,
-                    qualifier = viewModelQualifier,
-                    parameters = viewModelParameters,
-                )
-
-                @Suppress("UNCHECKED_CAST")
-                return viewModel as T
-            }
-        }
-
-    private fun viewModelDelegate(): ViewModelLazy<VM> =
-        ViewModelLazy(
-            viewModelClass,
-            { viewModelStore },
-            { provideViewModelFactory() },
-            { defaultViewModelCreationExtras },
-        )
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        viewModel
-    }
-}
+abstract class BaseActivity : AppCompatActivity()

--- a/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
@@ -2,6 +2,7 @@ package com.example.rise.baseclasses
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModel
 import kotlin.reflect.KClass
 import org.koin.androidx.viewmodel.ext.android.viewModelForClass
 import org.koin.core.parameter.ParametersDefinition
@@ -13,16 +14,18 @@ abstract class BaseActivity<VM : BaseViewModel> : AppCompatActivity() {
     protected open val viewModelParameters: ParametersDefinition? = null
     protected open val viewModelQualifier: Qualifier? = null
 
-    private val viewModelDelegate: Lazy<VM> = viewModelForClass(
+    private val viewModelDelegate: Lazy<out ViewModel> = viewModelForClass(
         clazz = viewModelClass,
         qualifier = viewModelQualifier,
         parameters = viewModelParameters,
     )
 
-    protected val viewModel: VM by viewModelDelegate
+    @Suppress("UNCHECKED_CAST")
+    protected val viewModel: VM
+        get() = viewModelDelegate.value as VM
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModel
+        viewModelDelegate.value
     }
 }

--- a/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseActivity.kt
@@ -1,16 +1,28 @@
 package com.example.rise.baseclasses
 
 import android.os.Bundle
-import android.os.PersistableBundle
 import androidx.appcompat.app.AppCompatActivity
+import kotlin.reflect.KClass
+import org.koin.androidx.viewmodel.ext.android.viewModelForClass
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
 
+abstract class BaseActivity<VM : BaseViewModel> : AppCompatActivity() {
 
-abstract class BaseActivity<viewModel: BaseViewModel>: AppCompatActivity() {
-    lateinit var  viewModel: viewModel
-    abstract fun createViewModel()
+    protected abstract val viewModelClass: KClass<VM>
+    protected open val viewModelParameters: ParametersDefinition? = null
+    protected open val viewModelQualifier: Qualifier? = null
 
-    override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
-        super.onCreate(savedInstanceState, persistentState)
-        createViewModel()
+    private val viewModelDelegate: Lazy<VM> = viewModelForClass(
+        clazz = viewModelClass,
+        qualifier = viewModelQualifier,
+        parameters = viewModelParameters,
+    )
+
+    protected val viewModel: VM by viewModelDelegate
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel
     }
 }

--- a/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
@@ -2,7 +2,7 @@ package com.example.rise.baseclasses
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModel
+import kotlin.LazyThreadSafetyMode
 import kotlin.reflect.KClass
 import org.koin.androidx.viewmodel.ext.android.viewModelForClass
 import org.koin.core.parameter.ParametersDefinition
@@ -14,18 +14,16 @@ abstract class BaseFragment<VM : BaseViewModel> : Fragment() {
     protected open val viewModelParameters: ParametersDefinition? = null
     protected open val viewModelQualifier: Qualifier? = null
 
-    private val viewModelDelegate: Lazy<out ViewModel> = viewModelForClass(
-        clazz = viewModelClass,
-        qualifier = viewModelQualifier,
-        parameters = viewModelParameters,
-    )
-
-    @Suppress("UNCHECKED_CAST")
-    protected val viewModel: VM
-        get() = viewModelDelegate.value as VM
+    protected val viewModel: VM by lazy(LazyThreadSafetyMode.NONE) {
+        viewModelForClass(
+            clazz = viewModelClass,
+            qualifier = viewModelQualifier,
+            parameters = viewModelParameters,
+        ).value
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModelDelegate.value
+        viewModel
     }
 }

--- a/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
@@ -1,51 +1,5 @@
 package com.example.rise.baseclasses
 
-import android.os.Bundle
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelLazy
-import kotlin.reflect.KClass
-import org.koin.android.ext.android.getKoin
-import org.koin.core.parameter.ParametersDefinition
-import org.koin.core.qualifier.Qualifier
 
-abstract class BaseFragment<VM : BaseViewModel> : Fragment() {
-
-    protected abstract val viewModelClass: KClass<VM>
-    protected open val viewModelParameters: ParametersDefinition? = null
-    protected open val viewModelQualifier: Qualifier? = null
-
-    protected val viewModel: VM by viewModelDelegate()
-
-    protected open fun provideViewModelFactory(): ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                if (!modelClass.isAssignableFrom(viewModelClass.java)) {
-                    throw IllegalArgumentException("Unknown ViewModel class: ${'$'}modelClass")
-                }
-
-                val viewModel: VM = getKoin().get(
-                    clazz = viewModelClass,
-                    qualifier = viewModelQualifier,
-                    parameters = viewModelParameters,
-                )
-
-                @Suppress("UNCHECKED_CAST")
-                return viewModel as T
-            }
-        }
-
-    private fun viewModelDelegate(): ViewModelLazy<VM> =
-        ViewModelLazy(
-            viewModelClass,
-            { viewModelStore },
-            { provideViewModelFactory() },
-            { defaultViewModelCreationExtras },
-        )
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        viewModel
-    }
-}
+abstract class BaseFragment : Fragment()

--- a/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
@@ -2,13 +2,27 @@ package com.example.rise.baseclasses
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
+import kotlin.reflect.KClass
+import org.koin.androidx.viewmodel.ext.android.viewModelForClass
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
 
-abstract class BaseFragment<viewModel: BaseViewModel>: Fragment() {
-    lateinit var viewModel: viewModel
-    abstract fun createViewModel()
+abstract class BaseFragment<VM : BaseViewModel> : Fragment() {
+
+    protected abstract val viewModelClass: KClass<VM>
+    protected open val viewModelParameters: ParametersDefinition? = null
+    protected open val viewModelQualifier: Qualifier? = null
+
+    private val viewModelDelegate: Lazy<VM> = viewModelForClass(
+        clazz = viewModelClass,
+        qualifier = viewModelQualifier,
+        parameters = viewModelParameters,
+    )
+
+    protected val viewModel: VM by viewModelDelegate
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        createViewModel()
+        viewModel
     }
 }

--- a/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
@@ -2,6 +2,7 @@ package com.example.rise.baseclasses
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
 import kotlin.reflect.KClass
 import org.koin.androidx.viewmodel.ext.android.viewModelForClass
 import org.koin.core.parameter.ParametersDefinition
@@ -13,16 +14,18 @@ abstract class BaseFragment<VM : BaseViewModel> : Fragment() {
     protected open val viewModelParameters: ParametersDefinition? = null
     protected open val viewModelQualifier: Qualifier? = null
 
-    private val viewModelDelegate: Lazy<VM> = viewModelForClass(
+    private val viewModelDelegate: Lazy<out ViewModel> = viewModelForClass(
         clazz = viewModelClass,
         qualifier = viewModelQualifier,
         parameters = viewModelParameters,
     )
 
-    protected val viewModel: VM by viewModelDelegate
+    @Suppress("UNCHECKED_CAST")
+    protected val viewModel: VM
+        get() = viewModelDelegate.value as VM
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModel
+        viewModelDelegate.value
     }
 }

--- a/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseFragment.kt
@@ -2,9 +2,11 @@ package com.example.rise.baseclasses
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
-import kotlin.LazyThreadSafetyMode
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelLazy
 import kotlin.reflect.KClass
-import org.koin.androidx.viewmodel.ext.android.viewModelForClass
+import org.koin.android.ext.android.getKoin
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 
@@ -14,13 +16,33 @@ abstract class BaseFragment<VM : BaseViewModel> : Fragment() {
     protected open val viewModelParameters: ParametersDefinition? = null
     protected open val viewModelQualifier: Qualifier? = null
 
-    protected val viewModel: VM by lazy(LazyThreadSafetyMode.NONE) {
-        viewModelForClass(
-            clazz = viewModelClass,
-            qualifier = viewModelQualifier,
-            parameters = viewModelParameters,
-        ).value
-    }
+    protected val viewModel: VM by viewModelDelegate()
+
+    protected open fun provideViewModelFactory(): ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                if (!modelClass.isAssignableFrom(viewModelClass.java)) {
+                    throw IllegalArgumentException("Unknown ViewModel class: ${'$'}modelClass")
+                }
+
+                val viewModel: VM = getKoin().get(
+                    clazz = viewModelClass,
+                    qualifier = viewModelQualifier,
+                    parameters = viewModelParameters,
+                )
+
+                @Suppress("UNCHECKED_CAST")
+                return viewModel as T
+            }
+        }
+
+    private fun viewModelDelegate(): ViewModelLazy<VM> =
+        ViewModelLazy(
+            viewModelClass,
+            { viewModelStore },
+            { provideViewModelFactory() },
+            { defaultViewModelCreationExtras },
+        )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/rise/baseclasses/BaseViewModel.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseViewModel.kt
@@ -1,5 +1,0 @@
-package com.example.rise.baseclasses
-
-import androidx.lifecycle.ViewModel
-
-open class BaseViewModel : ViewModel()

--- a/app/src/main/java/com/example/rise/baseclasses/BaseViewModel.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/BaseViewModel.kt
@@ -2,5 +2,4 @@ package com.example.rise.baseclasses
 
 import androidx.lifecycle.ViewModel
 
-open class BaseViewModel: ViewModel() {
-}
+open class BaseViewModel : ViewModel()

--- a/app/src/main/java/com/example/rise/baseclasses/KoinViewModelFactory.kt
+++ b/app/src/main/java/com/example/rise/baseclasses/KoinViewModelFactory.kt
@@ -1,0 +1,58 @@
+package com.example.rise.baseclasses
+
+import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import org.koin.android.ext.android.getKoin
+import org.koin.core.Koin
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
+import kotlin.reflect.KClass
+
+fun <VM : ViewModel> ComponentActivity.koinViewModelFactory(
+    viewModelClass: KClass<VM>,
+    qualifier: Qualifier? = null,
+    parameters: ParametersDefinition? = null,
+): ViewModelProvider.Factory =
+    createKoinViewModelFactory(
+        viewModelClass = viewModelClass,
+        qualifier = qualifier,
+        parameters = parameters,
+        koinProvider = { getKoin() },
+    )
+
+fun <VM : ViewModel> Fragment.koinViewModelFactory(
+    viewModelClass: KClass<VM>,
+    qualifier: Qualifier? = null,
+    parameters: ParametersDefinition? = null,
+): ViewModelProvider.Factory =
+    createKoinViewModelFactory(
+        viewModelClass = viewModelClass,
+        qualifier = qualifier,
+        parameters = parameters,
+        koinProvider = { getKoin() },
+    )
+
+private fun <VM : ViewModel> createKoinViewModelFactory(
+    viewModelClass: KClass<VM>,
+    qualifier: Qualifier?,
+    parameters: ParametersDefinition?,
+    koinProvider: () -> Koin,
+): ViewModelProvider.Factory =
+    object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (!modelClass.isAssignableFrom(viewModelClass.java)) {
+                throw IllegalArgumentException("Unknown ViewModel class: $modelClass")
+            }
+
+            val viewModel: VM = koinProvider().get(
+                clazz = viewModelClass,
+                qualifier = qualifier,
+                parameters = parameters,
+            )
+
+            @Suppress("UNCHECKED_CAST")
+            return viewModel as T
+        }
+    }

--- a/app/src/main/java/com/example/rise/data/alarm/ConfigReminderPreferences.kt
+++ b/app/src/main/java/com/example/rise/data/alarm/ConfigReminderPreferences.kt
@@ -1,0 +1,29 @@
+package com.example.rise.data.alarm
+
+import com.example.rise.helpers.Config
+
+class ConfigReminderPreferences(
+    private val config: Config,
+) : ReminderPreferences {
+
+    override val alarmMaxReminderSeconds: Int
+        get() = config.alarmMaxReminderSecs
+
+    override val timerMaxReminderSeconds: Int
+        get() = config.timerMaxReminderSecs
+
+    override val increaseVolumeGradually: Boolean
+        get() = config.increaseVolumeGradually
+
+    override val useSameSnooze: Boolean
+        get() = config.useSameSnooze
+
+    override var snoozeMinutes: Int
+        get() = config.snoozeTime
+        set(value) {
+            config.snoozeTime = value
+        }
+
+    override val timerSoundUri: String?
+        get() = config.timerSoundUri
+}

--- a/app/src/main/java/com/example/rise/data/alarm/ReminderPreferences.kt
+++ b/app/src/main/java/com/example/rise/data/alarm/ReminderPreferences.kt
@@ -1,0 +1,10 @@
+package com.example.rise.data.alarm
+
+interface ReminderPreferences {
+    val alarmMaxReminderSeconds: Int
+    val timerMaxReminderSeconds: Int
+    val increaseVolumeGradually: Boolean
+    val useSameSnooze: Boolean
+    var snoozeMinutes: Int
+    val timerSoundUri: String?
+}

--- a/app/src/main/java/com/example/rise/data/auth/AuthStateProvider.kt
+++ b/app/src/main/java/com/example/rise/data/auth/AuthStateProvider.kt
@@ -1,0 +1,9 @@
+package com.example.rise.data.auth
+
+interface AuthStateProvider {
+    fun isSignedIn(): Boolean
+
+    fun currentUserId(): String?
+
+    fun currentUserDisplayName(): String?
+}

--- a/app/src/main/java/com/example/rise/data/auth/FirebaseAuthStateProvider.kt
+++ b/app/src/main/java/com/example/rise/data/auth/FirebaseAuthStateProvider.kt
@@ -1,0 +1,11 @@
+package com.example.rise.data.auth
+
+import com.google.firebase.auth.FirebaseAuth
+
+class FirebaseAuthStateProvider(private val firebaseAuth: FirebaseAuth) : AuthStateProvider {
+    override fun isSignedIn(): Boolean = firebaseAuth.currentUser != null
+
+    override fun currentUserId(): String? = firebaseAuth.currentUser?.uid
+
+    override fun currentUserDisplayName(): String? = firebaseAuth.currentUser?.displayName
+}

--- a/app/src/main/java/com/example/rise/data/auth/FirebaseSignInRepository.kt
+++ b/app/src/main/java/com/example/rise/data/auth/FirebaseSignInRepository.kt
@@ -1,0 +1,31 @@
+package com.example.rise.data.auth
+
+import com.example.rise.services.MyFirebaseMessagingService
+import com.example.rise.util.FirestoreUtil
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.tasks.await
+import kotlin.coroutines.resume
+
+class FirebaseSignInRepository(
+    private val messaging: FirebaseMessaging,
+) : SignInRepository {
+
+    override suspend fun ensureUserInitialized() = suspendCancellableCoroutine { continuation ->
+        FirestoreUtil.initCurrentUserIfFirstTime {
+            if (continuation.isActive) {
+                continuation.resume(Unit)
+            }
+        }
+    }
+
+    override suspend fun fetchMessagingToken(): String? = try {
+        messaging.token.await()
+    } catch (error: Exception) {
+        null
+    }
+
+    override suspend fun storeMessagingToken(token: String) {
+        MyFirebaseMessagingService.addTokenToFirestore(token)
+    }
+}

--- a/app/src/main/java/com/example/rise/data/auth/FirebaseUiSignInIntentProvider.kt
+++ b/app/src/main/java/com/example/rise/data/auth/FirebaseUiSignInIntentProvider.kt
@@ -1,12 +1,21 @@
 package com.example.rise.data.auth
 
 import android.content.Intent
+import com.example.rise.R
 import com.firebase.ui.auth.AuthUI
 
 class FirebaseUiSignInIntentProvider(private val authUi: AuthUI) : SignInIntentProvider {
     override fun createSignInIntent(): Intent {
         return authUi.createSignInIntentBuilder()
-            .setAvailableProviders(listOf(AuthUI.IdpConfig.EmailBuilder().build()))
+            .setAvailableProviders(
+                listOf(
+                    AuthUI.IdpConfig.EmailBuilder()
+                        .setAllowNewAccounts(true)
+                        .setRequireName(true)
+                        .build(),
+                ),
+            )
+            .setLogo(R.drawable.ic_fire_emoji)
             .setIsSmartLockEnabled(false)
             .build()
     }

--- a/app/src/main/java/com/example/rise/data/auth/FirebaseUiSignInIntentProvider.kt
+++ b/app/src/main/java/com/example/rise/data/auth/FirebaseUiSignInIntentProvider.kt
@@ -1,0 +1,13 @@
+package com.example.rise.data.auth
+
+import android.content.Intent
+import com.firebase.ui.auth.AuthUI
+
+class FirebaseUiSignInIntentProvider(private val authUi: AuthUI) : SignInIntentProvider {
+    override fun createSignInIntent(): Intent {
+        return authUi.createSignInIntentBuilder()
+            .setAvailableProviders(listOf(AuthUI.IdpConfig.EmailBuilder().build()))
+            .setIsSmartLockEnabled(false)
+            .build()
+    }
+}

--- a/app/src/main/java/com/example/rise/data/auth/SignInIntentProvider.kt
+++ b/app/src/main/java/com/example/rise/data/auth/SignInIntentProvider.kt
@@ -2,6 +2,6 @@ package com.example.rise.data.auth
 
 import android.content.Intent
 
-interface SignInIntentProvider {
+fun interface SignInIntentProvider {
     fun createSignInIntent(): Intent
 }

--- a/app/src/main/java/com/example/rise/data/auth/SignInIntentProvider.kt
+++ b/app/src/main/java/com/example/rise/data/auth/SignInIntentProvider.kt
@@ -1,0 +1,7 @@
+package com.example.rise.data.auth
+
+import android.content.Intent
+
+interface SignInIntentProvider {
+    fun createSignInIntent(): Intent
+}

--- a/app/src/main/java/com/example/rise/data/auth/SignInRepository.kt
+++ b/app/src/main/java/com/example/rise/data/auth/SignInRepository.kt
@@ -1,0 +1,7 @@
+package com.example.rise.data.auth
+
+interface SignInRepository {
+    suspend fun ensureUserInitialized()
+    suspend fun fetchMessagingToken(): String?
+    suspend fun storeMessagingToken(token: String)
+}

--- a/app/src/main/java/com/example/rise/data/chat/ChatRepository.kt
+++ b/app/src/main/java/com/example/rise/data/chat/ChatRepository.kt
@@ -1,0 +1,16 @@
+package com.example.rise.data.chat
+
+import com.example.rise.models.TextMessage
+import kotlinx.coroutines.flow.Flow
+
+data class ChatUser(
+    val id: String,
+    val displayName: String
+)
+
+interface ChatRepository {
+    suspend fun getCurrentUser(): ChatUser
+    suspend fun getOrCreateChannel(otherUserId: String): String
+    fun observeMessages(channelId: String): Flow<List<TextMessage>>
+    suspend fun sendMessage(channelId: String, message: TextMessage)
+}

--- a/app/src/main/java/com/example/rise/data/chat/FirestoreChatRepository.kt
+++ b/app/src/main/java/com/example/rise/data/chat/FirestoreChatRepository.kt
@@ -1,0 +1,90 @@
+package com.example.rise.data.chat
+
+import com.example.rise.models.ChatChannel
+import com.example.rise.models.TextMessage
+import com.example.rise.models.User
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+
+class FirestoreChatRepository(
+    private val auth: FirebaseAuth,
+    private val firestore: FirebaseFirestore
+) : ChatRepository {
+
+    private val usersCollection get() = firestore.collection("users")
+    private val chatChannelsCollection get() = firestore.collection("chatChannels")
+
+    override suspend fun getCurrentUser(): ChatUser {
+        val firebaseUser = auth.currentUser ?: throw IllegalStateException("User must be signed in")
+        val snapshot = usersCollection.document(firebaseUser.uid).get().await()
+        val user = snapshot.toObject(User::class.java)
+        val displayName = user?.name?.takeIf { it.isNotBlank() }
+            ?: firebaseUser.displayName.orEmpty()
+        return ChatUser(
+            id = firebaseUser.uid,
+            displayName = displayName
+        )
+    }
+
+    override suspend fun getOrCreateChannel(otherUserId: String): String {
+        val currentUserId = auth.currentUser?.uid ?: throw IllegalStateException("User must be signed in")
+        val currentUserDoc = usersCollection.document(currentUserId)
+        val existingChannel = currentUserDoc
+            .collection("engagedChatChannels")
+            .document(otherUserId)
+            .get()
+            .await()
+        val existingId = existingChannel.getString("channelId")
+        if (existingId != null) {
+            return existingId
+        }
+
+        val newChannelDoc = chatChannelsCollection.document()
+        newChannelDoc.set(ChatChannel(mutableListOf(currentUserId, otherUserId))).await()
+
+        currentUserDoc
+            .collection("engagedChatChannels")
+            .document(otherUserId)
+            .set(mapOf("channelId" to newChannelDoc.id))
+            .await()
+
+        usersCollection
+            .document(otherUserId)
+            .collection("engagedChatChannels")
+            .document(currentUserId)
+            .set(mapOf("channelId" to newChannelDoc.id))
+            .await()
+
+        return newChannelDoc.id
+    }
+
+    override fun observeMessages(channelId: String): Flow<List<TextMessage>> = callbackFlow {
+        val registration = chatChannelsCollection
+            .document(channelId)
+            .collection("messages")
+            .orderBy("time")
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    close(error)
+                    return@addSnapshotListener
+                }
+                val messages = snapshot?.documents
+                    ?.mapNotNull { it.toObject(TextMessage::class.java) }
+                    .orEmpty()
+                trySend(messages).isSuccess
+            }
+        awaitClose { registration.remove() }
+    }
+
+    override suspend fun sendMessage(channelId: String, message: TextMessage) {
+        chatChannelsCollection
+            .document(channelId)
+            .collection("messages")
+            .add(message)
+            .await()
+    }
+}

--- a/app/src/main/java/com/example/rise/data/dashboard/AlarmRepository.kt
+++ b/app/src/main/java/com/example/rise/data/dashboard/AlarmRepository.kt
@@ -1,0 +1,9 @@
+package com.example.rise.data.dashboard
+
+import com.example.rise.models.Alarm
+import com.google.firebase.firestore.Query
+
+interface AlarmRepository {
+    fun alarmsQuery(userId: String): Query
+    suspend fun saveAlarm(userId: String, alarm: Alarm)
+}

--- a/app/src/main/java/com/example/rise/data/dashboard/FirestoreAlarmRepository.kt
+++ b/app/src/main/java/com/example/rise/data/dashboard/FirestoreAlarmRepository.kt
@@ -1,0 +1,29 @@
+package com.example.rise.data.dashboard
+
+import com.example.rise.models.Alarm
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import kotlinx.coroutines.tasks.await
+
+class FirestoreAlarmRepository(
+    private val firestore: FirebaseFirestore
+) : AlarmRepository {
+
+    private fun userDocument(userId: String) = firestore.collection("users").document(userId)
+
+    override fun alarmsQuery(userId: String): Query {
+        return userDocument(userId)
+            .collection("alarms")
+            .orderBy("timeInMiliseconds")
+    }
+
+    override suspend fun saveAlarm(userId: String, alarm: Alarm) {
+        val userDoc = userDocument(userId)
+        userDoc.collection("alarms")
+            .document(alarm.idTimeStamp.toString())
+            .set(alarm)
+            .await()
+        userDoc.update("id", FieldValue.increment(1)).await()
+    }
+}

--- a/app/src/main/java/com/example/rise/data/myaccount/FirebaseMyAccountRepository.kt
+++ b/app/src/main/java/com/example/rise/data/myaccount/FirebaseMyAccountRepository.kt
@@ -1,0 +1,48 @@
+package com.example.rise.data.myaccount
+
+import android.content.Context
+import com.example.rise.models.User
+import com.firebase.ui.auth.AuthUI
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+
+class FirebaseMyAccountRepository(
+    private val auth: FirebaseAuth,
+    private val firestore: FirebaseFirestore,
+    private val authUI: AuthUI,
+    private val context: Context,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : MyAccountRepository {
+
+    override suspend fun fetchCurrentUser(): User = withContext(ioDispatcher) {
+        val uid = auth.currentUser?.uid ?: throw IllegalStateException("UID is null.")
+        val snapshot = firestore.collection("users").document(uid).get().await()
+        snapshot.toObject(User::class.java) ?: throw IllegalStateException("User not found")
+    }
+
+    override suspend fun updateCurrentUser(name: String, bio: String) {
+        withContext(ioDispatcher) {
+            val uid = auth.currentUser?.uid ?: throw IllegalStateException("UID is null.")
+            val updates = mutableMapOf<String, Any>()
+            if (name.isNotBlank()) {
+                updates["name"] = name
+            }
+            if (bio.isNotBlank()) {
+                updates["bio"] = bio
+            }
+            if (updates.isEmpty()) return@withContext
+
+            firestore.collection("users").document(uid).update(updates).await()
+        }
+    }
+
+    override suspend fun signOut() {
+        withContext(ioDispatcher) {
+            authUI.signOut(context).await()
+        }
+    }
+}

--- a/app/src/main/java/com/example/rise/data/myaccount/MyAccountRepository.kt
+++ b/app/src/main/java/com/example/rise/data/myaccount/MyAccountRepository.kt
@@ -1,0 +1,9 @@
+package com.example.rise.data.myaccount
+
+import com.example.rise.models.User
+
+interface MyAccountRepository {
+    suspend fun fetchCurrentUser(): User
+    suspend fun updateCurrentUser(name: String, bio: String)
+    suspend fun signOut()
+}

--- a/app/src/main/java/com/example/rise/data/people/FirestorePeopleRepository.kt
+++ b/app/src/main/java/com/example/rise/data/people/FirestorePeopleRepository.kt
@@ -1,0 +1,39 @@
+package com.example.rise.data.people
+
+import com.example.rise.models.User
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+class FirestorePeopleRepository(
+    private val auth: FirebaseAuth,
+    private val firestore: FirebaseFirestore
+) : PeopleRepository {
+
+    override fun observePeople(): Flow<List<PersonSummary>> = callbackFlow {
+        val registration = firestore.collection("users")
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    close(error)
+                    return@addSnapshotListener
+                }
+                val currentUserId = auth.currentUser?.uid
+                val people = snapshot?.documents
+                    ?.mapNotNull { document ->
+                        if (document.id == currentUserId) return@mapNotNull null
+                        val user = document.toObject(User::class.java) ?: return@mapNotNull null
+                        PersonSummary(
+                            id = document.id,
+                            name = user.name,
+                            bio = user.bio,
+                            profilePicturePath = user.profilePicturePath
+                        )
+                    }
+                    .orEmpty()
+                trySend(people).isSuccess
+            }
+        awaitClose { registration.remove() }
+    }
+}

--- a/app/src/main/java/com/example/rise/data/people/PeopleRepository.kt
+++ b/app/src/main/java/com/example/rise/data/people/PeopleRepository.kt
@@ -1,0 +1,14 @@
+package com.example.rise.data.people
+
+import kotlinx.coroutines.flow.Flow
+
+data class PersonSummary(
+    val id: String,
+    val name: String,
+    val bio: String,
+    val profilePicturePath: String?
+)
+
+interface PeopleRepository {
+    fun observePeople(): Flow<List<PersonSummary>>
+}

--- a/app/src/main/java/com/example/rise/ui/SplashActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/SplashActivity.kt
@@ -1,21 +1,24 @@
 package com.example.rise.ui
 
-
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.example.rise.baseclasses.BaseActivity
+import com.example.rise.baseclasses.koinViewModelFactory
 import com.example.rise.ui.SplashActivityViewModel.NavigationEvent
 import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInActivity
 import com.example.rise.ui.mainActivity.MainActivity
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
-class SplashActivity : BaseActivity<SplashActivityViewModel>() {
+class SplashActivity : BaseActivity() {
 
-    override val viewModelClass = SplashActivityViewModel::class
+    private val viewModel: SplashActivityViewModel by viewModels {
+        koinViewModelFactory(SplashActivityViewModel::class)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/rise/ui/SplashActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/SplashActivity.kt
@@ -4,30 +4,32 @@ package com.example.rise.ui
 import android.content.Intent
 import android.os.Bundle
 
+import androidx.lifecycle.lifecycleScope
 import com.example.rise.baseclasses.BaseActivity
+import com.example.rise.ui.SplashActivityViewModel.NavigationEvent
 import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInActivity
 import com.example.rise.ui.mainActivity.MainActivity
 import com.google.firebase.FirebaseApp
-import com.google.firebase.auth.FirebaseAuth
-import org.koin.android.ext.android.get
-import org.koin.dsl.koinApplication
+import kotlinx.coroutines.flow.collect
 
 class SplashActivity : BaseActivity<SplashActivityViewModel>() {
+
+    override val viewModelClass = SplashActivityViewModel::class
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         FirebaseApp.initializeApp(this)
-        if (FirebaseAuth.getInstance().currentUser == null) {
-            val intent = Intent(this, SignInActivity::class.java)
-            startActivity(intent)
-        } else {
-            val intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
-        }
-        finish()
-    }
 
-    override fun createViewModel() {
-        viewModel = get()
+        lifecycleScope.launchWhenStarted {
+            viewModel.events.collect { event ->
+                when (event) {
+                    NavigationEvent.ToSignIn -> startActivity(Intent(this@SplashActivity, SignInActivity::class.java))
+                    NavigationEvent.ToMain -> startActivity(Intent(this@SplashActivity, MainActivity::class.java))
+                }
+                finish()
+            }
+        }
+
+        viewModel.determineDestination()
     }
 }

--- a/app/src/main/java/com/example/rise/ui/SplashActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/SplashActivity.kt
@@ -3,14 +3,15 @@ package com.example.rise.ui
 
 import android.content.Intent
 import android.os.Bundle
-
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.rise.baseclasses.BaseActivity
 import com.example.rise.ui.SplashActivityViewModel.NavigationEvent
 import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInActivity
 import com.example.rise.ui.mainActivity.MainActivity
-import com.google.firebase.FirebaseApp
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 
 class SplashActivity : BaseActivity<SplashActivityViewModel>() {
 
@@ -18,18 +19,21 @@ class SplashActivity : BaseActivity<SplashActivityViewModel>() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        FirebaseApp.initializeApp(this)
-
-        lifecycleScope.launchWhenStarted {
-            viewModel.events.collect { event ->
-                when (event) {
-                    NavigationEvent.ToSignIn -> startActivity(Intent(this@SplashActivity, SignInActivity::class.java))
-                    NavigationEvent.ToMain -> startActivity(Intent(this@SplashActivity, MainActivity::class.java))
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.events.collect { event ->
+                    when (event) {
+                        NavigationEvent.ToSignIn -> startActivity(Intent(this@SplashActivity, SignInActivity::class.java))
+                        NavigationEvent.ToMain -> startActivity(Intent(this@SplashActivity, MainActivity::class.java))
+                    }
+                    finish()
                 }
-                finish()
             }
         }
+    }
 
+    override fun onStart() {
+        super.onStart()
         viewModel.determineDestination()
     }
 }

--- a/app/src/main/java/com/example/rise/ui/SplashActivityViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/SplashActivityViewModel.kt
@@ -1,7 +1,28 @@
 package com.example.rise.ui
 
 import com.example.rise.baseclasses.BaseViewModel
+import com.example.rise.data.auth.AuthStateProvider
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
-class SplashActivityViewModel: BaseViewModel() {
+class SplashActivityViewModel(
+    private val authStateProvider: AuthStateProvider
+) : BaseViewModel() {
 
+    sealed interface NavigationEvent {
+        data object ToSignIn : NavigationEvent
+        data object ToMain : NavigationEvent
+    }
+
+    private val _events = MutableSharedFlow<NavigationEvent>(extraBufferCapacity = 1)
+    val events = _events.asSharedFlow()
+
+    fun determineDestination() {
+        val event = if (authStateProvider.isSignedIn()) {
+            NavigationEvent.ToMain
+        } else {
+            NavigationEvent.ToSignIn
+        }
+        _events.tryEmit(event)
+    }
 }

--- a/app/src/main/java/com/example/rise/ui/SplashActivityViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/SplashActivityViewModel.kt
@@ -14,7 +14,7 @@ class SplashActivityViewModel(
         data object ToMain : NavigationEvent
     }
 
-    private val _events = MutableSharedFlow<NavigationEvent>(extraBufferCapacity = 1)
+    private val _events = MutableSharedFlow<NavigationEvent>(replay = 1)
     val events = _events.asSharedFlow()
 
     fun determineDestination() {

--- a/app/src/main/java/com/example/rise/ui/SplashActivityViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/SplashActivityViewModel.kt
@@ -1,13 +1,13 @@
 package com.example.rise.ui
 
-import com.example.rise.baseclasses.BaseViewModel
+import androidx.lifecycle.ViewModel
 import com.example.rise.data.auth.AuthStateProvider
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
 class SplashActivityViewModel(
-    private val authStateProvider: AuthStateProvider
-) : BaseViewModel() {
+    private val authStateProvider: AuthStateProvider,
+) : ViewModel() {
 
     sealed interface NavigationEvent {
         data object ToSignIn : NavigationEvent

--- a/app/src/main/java/com/example/rise/ui/alarm/ReminderViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/alarm/ReminderViewModel.kt
@@ -1,0 +1,194 @@
+package com.example.rise.ui.alarm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.rise.data.alarm.ReminderPreferences
+import com.example.rise.helpers.MINUTE_SECONDS
+import com.example.rise.models.Alarm
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.math.min
+
+class ReminderViewModel(
+    private val preferences: ReminderPreferences,
+) : ViewModel() {
+
+    data class Args(
+        val alarm: Alarm?,
+        val isAlarmReminder: Boolean,
+        val alarmLabelFallback: String,
+        val timerLabel: String,
+        val timerExpiredText: String,
+        val formattedTimeProvider: () -> CharSequence,
+    )
+
+    data class UiState(
+        val title: String = "",
+        val message: CharSequence = "",
+        val isAlarmReminder: Boolean = false,
+        val soundUri: String? = null,
+        val currentVolume: Float = 1f,
+        val increaseVolumeGradually: Boolean = false,
+        val isInitialized: Boolean = false,
+    )
+
+    sealed interface Event {
+        object Finish : Event
+        data class ScheduleSnooze(val alarm: Alarm, val seconds: Int) : Event
+        data class ShowSnoozePicker(val defaultSeconds: Int, val alarm: Alarm) : Event
+        data class UpdateVolume(val volume: Float) : Event
+    }
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<Event>(extraBufferCapacity = 1)
+    val events = _events.asSharedFlow()
+
+    private var initialized = false
+    private var alarm: Alarm? = null
+    private var autoFinishJob: Job? = null
+    private var volumeJob: Job? = null
+    private var hasTerminated = false
+
+    fun initialize(args: Args) {
+        if (initialized) return
+        initialized = true
+        alarm = args.alarm
+
+        val title = if (args.isAlarmReminder) {
+            val label = args.alarm?.label.orEmpty()
+            if (label.isBlank()) {
+                args.alarmLabelFallback
+            } else {
+                label
+            }
+        } else {
+            args.timerLabel
+        }
+
+        val message = if (args.isAlarmReminder) {
+            args.formattedTimeProvider()
+        } else {
+            args.timerExpiredText
+        }
+
+        val shouldIncreaseVolume = args.isAlarmReminder && preferences.increaseVolumeGradually
+        val soundUri = args.alarm?.soundUri ?: preferences.timerSoundUri
+        val initialVolume = if (shouldIncreaseVolume) MIN_VOLUME else 1f
+
+        _uiState.value = UiState(
+            title = title,
+            message = message,
+            isAlarmReminder = args.isAlarmReminder,
+            soundUri = soundUri,
+            currentVolume = initialVolume,
+            increaseVolumeGradually = shouldIncreaseVolume,
+            isInitialized = true,
+        )
+
+        val maxDurationSeconds = if (args.isAlarmReminder) {
+            preferences.alarmMaxReminderSeconds
+        } else {
+            preferences.timerMaxReminderSeconds
+        }
+        scheduleAutoFinish(maxDurationSeconds)
+
+        if (shouldIncreaseVolume) {
+            scheduleVolumeIncrease(initialVolume)
+        }
+    }
+
+    fun onDismissRequested() {
+        finishReminder()
+    }
+
+    fun onNewIntent() {
+        finishReminder()
+    }
+
+    fun onSnoozeRequested() {
+        val alarm = alarm ?: run {
+            finishReminder()
+            return
+        }
+
+        cancelJobs()
+        if (preferences.useSameSnooze) {
+            val seconds = preferences.snoozeMinutes * MINUTE_SECONDS
+            sendScheduleSnooze(alarm, seconds)
+        } else {
+            val seconds = preferences.snoozeMinutes * MINUTE_SECONDS
+            _events.tryEmit(Event.ShowSnoozePicker(seconds, alarm))
+        }
+    }
+
+    fun onSnoozeDurationSelected(seconds: Int) {
+        val alarm = alarm ?: return
+        preferences.snoozeMinutes = seconds / MINUTE_SECONDS
+        sendScheduleSnooze(alarm, seconds)
+    }
+
+    fun onSnoozePickerCancelled() {
+        finishReminder()
+    }
+
+    private fun sendScheduleSnooze(alarm: Alarm, seconds: Int) {
+        cancelJobs()
+        hasTerminated = true
+        _events.tryEmit(Event.ScheduleSnooze(alarm, seconds))
+    }
+
+    private fun finishReminder() {
+        if (hasTerminated) return
+        cancelJobs()
+        hasTerminated = true
+        _events.tryEmit(Event.Finish)
+    }
+
+    private fun scheduleAutoFinish(durationSeconds: Int) {
+        if (durationSeconds <= 0) {
+            finishReminder()
+            return
+        }
+
+        autoFinishJob = viewModelScope.launch {
+            delay(durationSeconds * 1000L)
+            finishReminder()
+        }
+    }
+
+    private fun scheduleVolumeIncrease(startVolume: Float) {
+        volumeJob = viewModelScope.launch {
+            var volume = startVolume
+            while (volume < 1f && !hasTerminated) {
+                delay(VOLUME_DELAY_MS)
+                volume = min(1f, volume + VOLUME_STEP)
+                _events.emit(Event.UpdateVolume(volume))
+            }
+        }
+    }
+
+    private fun cancelJobs() {
+        autoFinishJob?.cancel()
+        autoFinishJob = null
+        volumeJob?.cancel()
+        volumeJob = null
+    }
+
+    override fun onCleared() {
+        cancelJobs()
+        super.onCleared()
+    }
+
+    companion object {
+        private const val VOLUME_STEP = 0.1f
+        private const val MIN_VOLUME = 0.1f
+        private const val VOLUME_DELAY_MS = 3000L
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardFragment.kt
@@ -5,65 +5,33 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.DatePicker
-import androidx.annotation.RequiresApi
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.rise.R
 import com.example.rise.baseclasses.BaseFragment
 import com.example.rise.databinding.FragmentDashboardBinding
 import com.example.rise.extensions.scheduleNextAlarm
 import com.example.rise.helpers.CHAT_CHANNEL
 import com.example.rise.helpers.MESSAGE_CONTENT
-import com.example.rise.helpers.MINUTE_SECONDS
-import com.example.rise.models.Alarm
 import com.example.rise.models.TextMessage
 import com.example.rise.ui.dashboardNavigation.dashboard.recyclerview.MyFireStoreAlarmRecyclerViewAdapter
 import com.google.android.material.snackbar.Snackbar
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.firestore.Query
-import org.koin.android.ext.android.get
-import timber.log.Timber
 import java.util.Calendar
+import kotlinx.coroutines.flow.collect
 
 class DashboardFragment : BaseFragment<DashboardViewModel>() {
 
+    override val viewModelClass = DashboardViewModel::class
+
     var byBottomNavigation: Boolean = false
-
-    private lateinit var mQuery: Query
-    private lateinit var myFireStoreAlarmRecyclerViewAdapter: MyFireStoreAlarmRecyclerViewAdapter
-    private val tag = "DASHBOARD_FRAGMENT"
-
-    private var firstrun: Boolean = true
-    private var userID: String? = null
-    private lateinit var alarm: Alarm
-
-    private val firestoreInstance: FirebaseFirestore by lazy { FirebaseFirestore.getInstance() }
-
-    private var mFirestore: DocumentReference = firestoreInstance.document(
-        "users/${FirebaseAuth.getInstance().currentUser?.uid ?: throw NullPointerException("UID is null.")}"
-    )
 
     private var _binding: FragmentDashboardBinding? = null
     private val binding get() = _binding!!
 
-    override fun onStart() {
-        super.onStart()
-        if (::myFireStoreAlarmRecyclerViewAdapter.isInitialized) {
-            myFireStoreAlarmRecyclerViewAdapter.startListening()
-        }
-    }
-
-    override fun onStop() {
-        super.onStop()
-        if (::myFireStoreAlarmRecyclerViewAdapter.isInitialized) {
-            myFireStoreAlarmRecyclerViewAdapter.stopListening()
-        }
-    }
+    private var alarmAdapter: MyFireStoreAlarmRecyclerViewAdapter? = null
+    private var currentQuery: Query? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -74,95 +42,116 @@ class DashboardFragment : BaseFragment<DashboardViewModel>() {
         return binding.root
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         FirebaseFirestore.setLoggingEnabled(true)
-
-        binding.floatingActionButton.setOnClickListener {
-            alarm = Alarm()
-            firstrun = false
-
-            alarm.chatChannel = activity?.intent?.getStringExtra(CHAT_CHANNEL).orEmpty()
-            alarm.messsage = activity?.intent?.getParcelableExtra<TextMessage>(MESSAGE_CONTENT)
-            alarm.userName = FirebaseAuth.getInstance().currentUser?.displayName.orEmpty()
-
-            val datePicker = DatePicker(view.context)
-            val cal: Calendar = Calendar.getInstance()
-
-            cal.set(Calendar.DAY_OF_MONTH, datePicker.dayOfMonth)
-            cal.set(Calendar.MONTH, datePicker.month)
-            cal.set(Calendar.YEAR, datePicker.year)
-            cal.set(Calendar.HOUR_OF_DAY, binding.simpleTimePicker.hour)
-            cal.set(Calendar.MINUTE, binding.simpleTimePicker.minute)
-
-            val millis: Long = cal.timeInMillis
-
-            alarm.timeInMiliseconds = millis
-            alarm.idTimeStamp = System.currentTimeMillis().toInt()
-
-            if (alarm.messsage != null) {
-                context?.scheduleNextAlarm(alarm, true)
-            }
-
-            mQuery = queryFirestore()
-        }
-
-        val userID: String? = activity?.intent?.getStringExtra("UsrID")
-        val chatChannel: String? = activity?.intent?.getStringExtra("ChannelId")
-        val message = activity?.intent?.getParcelableExtra<TextMessage>("Message")
-
-        if (userID != null && !byBottomNavigation) {
-            this.userID = userID
-            mFirestore = firestoreInstance.document(
-                "users/$userID"
-            )
-        }
-
-        alarm = Alarm()
-        alarm.chatChannel = chatChannel.orEmpty()
-        alarm.messsage = message
-        mQuery = queryFirestore()
-        initRecyclerView(mQuery)
+        setupRecyclerView()
+        setupFab()
+        observeState()
+        observeEvents()
+        initialiseViewModel()
     }
 
-    private fun queryFirestore(): CollectionReference {
-        if (!firstrun) {
-            mFirestore.collection("alarms")
-            mFirestore.update("id", FieldValue.increment(1))
-            mFirestore.collection("alarms")
-                .document(alarm.idTimeStamp.toString()).set(alarm)
-                .addOnSuccessListener {
-                    Timber.d("DocumentSnapshot add with ID: ")
-                }
-                .addOnFailureListener { e ->
-                    Timber.tag(tag).w(e, "Error adding document")
-                }
-        }
-        return mFirestore.collection("alarms")
+    override fun onStart() {
+        super.onStart()
+        alarmAdapter?.startListening()
     }
 
-    private fun initRecyclerView(query: Query) {
-        myFireStoreAlarmRecyclerViewAdapter = object : MyFireStoreAlarmRecyclerViewAdapter(query, requireContext()) {
-            override fun onError(e: FirebaseFirestoreException) = Snackbar.make(
-                binding.root,
-                "Error: check logs for info.",
-                Snackbar.LENGTH_LONG
-            ).show()
-        }
+    override fun onStop() {
+        super.onStop()
+        alarmAdapter?.stopListening()
+    }
 
-        myFireStoreAlarmRecyclerViewAdapter.otherUsrId = this.userID
+    private fun setupRecyclerView() {
         binding.alarmList.layoutManager = LinearLayoutManager(context)
-        binding.alarmList.adapter = myFireStoreAlarmRecyclerViewAdapter
-        myFireStoreAlarmRecyclerViewAdapter.setQuery(query)
+    }
+
+    private fun setupFab() {
+        binding.floatingActionButton.setOnClickListener {
+            val timeInMillis = selectedTimeInMillis()
+            viewModel.createAlarm(timeInMillis)
+        }
+    }
+
+    private fun observeState() {
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            viewModel.uiState.collect { state ->
+                state.alarmQuery?.let { updateAdapter(it, state.activeUserId) }
+                state.errorMessage?.let { showError(it) }
+            }
+        }
+    }
+
+    private fun observeEvents() {
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is DashboardViewModel.DashboardEvent.ScheduleAlarm ->
+                        context?.scheduleNextAlarm(event.alarm, true)
+                }
+            }
+        }
+    }
+
+    private fun initialiseViewModel() {
+        val intent = activity?.intent
+        val explicitUserId = intent?.getStringExtra("UsrID")
+        val chatChannel = intent?.getStringExtra("ChannelId") ?: intent?.getStringExtra(CHAT_CHANNEL)
+        val message = intent?.getParcelableExtra<TextMessage>(MESSAGE_CONTENT)
+        viewModel.initialise(byBottomNavigation, explicitUserId, chatChannel, message)
+    }
+
+    private fun updateAdapter(query: Query, otherUserId: String?) {
+        if (alarmAdapter == null) {
+            alarmAdapter = object : MyFireStoreAlarmRecyclerViewAdapter(query, requireContext()) {
+                override fun onError(e: FirebaseFirestoreException) {
+                    Snackbar.make(binding.root, "Error: check logs for info.", Snackbar.LENGTH_LONG).show()
+                }
+            }
+            binding.alarmList.adapter = alarmAdapter
+            alarmAdapter?.otherUsrId = otherUserId
+            alarmAdapter?.startListening()
+        } else if (currentQuery != query) {
+            alarmAdapter?.setQuery(query)
+            alarmAdapter?.otherUsrId = otherUserId
+        } else {
+            alarmAdapter?.otherUsrId = otherUserId
+        }
+        currentQuery = query
+    }
+
+    private fun selectedTimeInMillis(): Long {
+        val calendar = Calendar.getInstance()
+        calendar.set(Calendar.SECOND, 0)
+        calendar.set(Calendar.MILLISECOND, 0)
+        calendar.set(Calendar.HOUR_OF_DAY, getSelectedHour())
+        calendar.set(Calendar.MINUTE, getSelectedMinute())
+        return calendar.timeInMillis
+    }
+
+    private fun getSelectedHour(): Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        binding.simpleTimePicker.hour
+    } else {
+        @Suppress("DEPRECATION")
+        binding.simpleTimePicker.currentHour
+    }
+
+    private fun getSelectedMinute(): Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        binding.simpleTimePicker.minute
+    } else {
+        @Suppress("DEPRECATION")
+        binding.simpleTimePicker.currentMinute
+    }
+
+    private fun showError(message: String) {
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG).show()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
+        alarmAdapter?.stopListening()
+        alarmAdapter = null
+        currentQuery = null
         _binding = null
-    }
-
-    override fun createViewModel() {
-        viewModel = get()
     }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardFragment.kt
@@ -5,9 +5,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.rise.baseclasses.BaseFragment
+import com.example.rise.baseclasses.koinViewModelFactory
 import com.example.rise.databinding.FragmentDashboardBinding
 import com.example.rise.extensions.scheduleNextAlarm
 import com.example.rise.helpers.CHAT_CHANNEL
@@ -21,9 +23,11 @@ import com.google.firebase.firestore.Query
 import java.util.Calendar
 import kotlinx.coroutines.flow.collect
 
-class DashboardFragment : BaseFragment<DashboardViewModel>() {
+class DashboardFragment : BaseFragment() {
 
-    override val viewModelClass = DashboardViewModel::class
+    private val viewModel: DashboardViewModel by viewModels {
+        koinViewModelFactory(DashboardViewModel::class)
+    }
 
     var byBottomNavigation: Boolean = false
 
@@ -36,7 +40,7 @@ class DashboardFragment : BaseFragment<DashboardViewModel>() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentDashboardBinding.inflate(inflater, container, false)
         return binding.root

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModel.kt
@@ -1,6 +1,88 @@
 package com.example.rise.ui.dashboardNavigation.dashboard
 
+import androidx.lifecycle.viewModelScope
 import com.example.rise.baseclasses.BaseViewModel
+import com.example.rise.data.dashboard.AlarmRepository
+import com.example.rise.models.Alarm
+import com.example.rise.models.TextMessage
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.Query
+import java.time.Clock
+import java.time.Instant
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
-class DashboardViewModel: BaseViewModel() {
+class DashboardViewModel(
+    private val repository: AlarmRepository,
+    private val auth: FirebaseAuth,
+    private val clock: Clock = Clock.systemDefaultZone()
+) : BaseViewModel() {
+
+    data class DashboardUiState(
+        val alarmQuery: Query? = null,
+        val activeUserId: String? = null,
+        val chatChannel: String = "",
+        val pendingMessage: TextMessage? = null,
+        val isLoading: Boolean = true,
+        val errorMessage: String? = null
+    )
+
+    sealed interface DashboardEvent {
+        data class ScheduleAlarm(val alarm: Alarm) : DashboardEvent
+    }
+
+    private val _uiState = MutableStateFlow(DashboardUiState())
+    val uiState = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<DashboardEvent>(extraBufferCapacity = 1)
+    val events = _events.asSharedFlow()
+
+    fun initialise(
+        byBottomNavigation: Boolean,
+        explicitUserId: String?,
+        chatChannel: String?,
+        message: TextMessage?
+    ) {
+        val resolvedUserId = if (!byBottomNavigation && !explicitUserId.isNullOrBlank()) {
+            explicitUserId
+        } else {
+            auth.currentUser?.uid ?: throw IllegalStateException("User must be signed in")
+        }
+        val query = repository.alarmsQuery(resolvedUserId)
+        _uiState.value = DashboardUiState(
+            alarmQuery = query,
+            activeUserId = resolvedUserId,
+            chatChannel = chatChannel.orEmpty(),
+            pendingMessage = message,
+            isLoading = false,
+            errorMessage = null
+        )
+    }
+
+    fun createAlarm(timeInMillis: Long, messageOverride: TextMessage? = null) {
+        val state = _uiState.value
+        val userId = state.activeUserId ?: return
+        val message = messageOverride ?: state.pendingMessage
+        val alarm = Alarm(
+            idTimeStamp = Instant.now(clock).toEpochMilli().toInt(),
+            timeInMiliseconds = timeInMillis,
+            userName = auth.currentUser?.displayName.orEmpty(),
+            chatChannel = state.chatChannel,
+            messsage = message
+        )
+        viewModelScope.launch {
+            try {
+                repository.saveAlarm(userId, alarm)
+                if (alarm.messsage != null) {
+                    _events.emit(DashboardEvent.ScheduleAlarm(alarm))
+                }
+            } catch (error: Throwable) {
+                _uiState.update { it.copy(errorMessage = error.message) }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModel.kt
@@ -1,7 +1,7 @@
 package com.example.rise.ui.dashboardNavigation.dashboard
 
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rise.baseclasses.BaseViewModel
 import com.example.rise.data.dashboard.AlarmRepository
 import com.example.rise.models.Alarm
 import com.example.rise.models.TextMessage
@@ -19,8 +19,8 @@ import kotlinx.coroutines.launch
 class DashboardViewModel(
     private val repository: AlarmRepository,
     private val auth: FirebaseAuth,
-    private val clock: Clock = Clock.systemDefaultZone()
-) : BaseViewModel() {
+    private val clock: Clock = Clock.systemDefaultZone(),
+) : ViewModel() {
 
     data class DashboardUiState(
         val alarmQuery: Query? = null,
@@ -28,7 +28,7 @@ class DashboardViewModel(
         val chatChannel: String = "",
         val pendingMessage: TextMessage? = null,
         val isLoading: Boolean = true,
-        val errorMessage: String? = null
+        val errorMessage: String? = null,
     )
 
     sealed interface DashboardEvent {
@@ -45,7 +45,7 @@ class DashboardViewModel(
         byBottomNavigation: Boolean,
         explicitUserId: String?,
         chatChannel: String?,
-        message: TextMessage?
+        message: TextMessage?,
     ) {
         val resolvedUserId = if (!byBottomNavigation && !explicitUserId.isNullOrBlank()) {
             explicitUserId
@@ -59,7 +59,7 @@ class DashboardViewModel(
             chatChannel = chatChannel.orEmpty(),
             pendingMessage = message,
             isLoading = false,
-            errorMessage = null
+            errorMessage = null,
         )
     }
 
@@ -72,7 +72,7 @@ class DashboardViewModel(
             timeInMiliseconds = timeInMillis,
             userName = auth.currentUser?.displayName.orEmpty(),
             chatChannel = state.chatChannel,
-            messsage = message
+            messsage = message,
         )
         viewModelScope.launch {
             try {

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountBaseViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountBaseViewModel.kt
@@ -1,7 +1,5 @@
 package com.example.rise.ui.dashboardNavigation.myAccount
 
-import com.example.rise.baseclasses.BaseViewModel
+import androidx.lifecycle.ViewModel
 
-class MyAccountBaseViewModel: BaseViewModel(
-) {
-}
+class MyAccountBaseViewModel : ViewModel()

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountBaseViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountBaseViewModel.kt
@@ -1,5 +1,87 @@
 package com.example.rise.ui.dashboardNavigation.myAccount
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.rise.data.myaccount.MyAccountRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
-class MyAccountBaseViewModel : ViewModel()
+class MyAccountBaseViewModel(
+    private val repository: MyAccountRepository,
+) : ViewModel() {
+
+    data class UiState(
+        val name: String = "",
+        val bio: String = "",
+        val isLoading: Boolean = false,
+        val isSaving: Boolean = false,
+        val errorMessage: String? = null,
+    )
+
+    sealed interface Event {
+        data class ShowMessage(val message: String) : Event
+        object NavigateToSignIn : Event
+    }
+
+    private val _uiState = MutableStateFlow(UiState(isLoading = true))
+    val uiState = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<Event>(extraBufferCapacity = 1)
+    val events = _events.asSharedFlow()
+
+    fun loadProfile() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            try {
+                val user = repository.fetchCurrentUser()
+                _uiState.update {
+                    it.copy(
+                        name = user.name,
+                        bio = user.bio,
+                        isLoading = false,
+                        errorMessage = null,
+                    )
+                }
+            } catch (error: Exception) {
+                _uiState.update { it.copy(isLoading = false, errorMessage = error.message) }
+                _events.tryEmit(Event.ShowMessage(error.message ?: "Failed to load profile"))
+            }
+        }
+    }
+
+    fun updateProfile(name: String, bio: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, errorMessage = null) }
+            try {
+                repository.updateCurrentUser(name, bio)
+                _uiState.update {
+                    it.copy(
+                        name = name,
+                        bio = bio,
+                        isSaving = false,
+                        errorMessage = null,
+                    )
+                }
+                _events.tryEmit(Event.ShowMessage("saving"))
+            } catch (error: Exception) {
+                _uiState.update { it.copy(isSaving = false, errorMessage = error.message) }
+                _events.tryEmit(Event.ShowMessage(error.message ?: "Failed to save profile"))
+            }
+        }
+    }
+
+    fun signOut() {
+        viewModelScope.launch {
+            try {
+                repository.signOut()
+                _events.emit(Event.NavigateToSignIn)
+            } catch (error: Exception) {
+                _events.emit(Event.ShowMessage(error.message ?: "Failed to sign out"))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountFragment.kt
@@ -7,15 +7,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.fragment.app.viewModels
 import com.example.rise.baseclasses.BaseFragment
+import com.example.rise.baseclasses.koinViewModelFactory
 import com.example.rise.databinding.FragmentMyAccountBinding
 import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInActivity
 import com.example.rise.util.FirestoreUtil
 import com.firebase.ui.auth.AuthUI
 
-class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
+class MyAccountFragment : BaseFragment() {
 
-    override val viewModelClass = MyAccountBaseViewModel::class
+    private val viewModel: MyAccountBaseViewModel by viewModels {
+        koinViewModelFactory(MyAccountBaseViewModel::class)
+    }
 
     private val RC_SELECT_IMAGE = 2
     private lateinit var selectedImageBytes: ByteArray
@@ -26,7 +30,7 @@ class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentMyAccountBinding.inflate(inflater, container, false)
 
@@ -41,7 +45,7 @@ class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
 
         binding.btnSave.setOnClickListener {
             if (::selectedImageBytes.isInitialized) {
-                // StorageUtil.uploadProfilePhoto(selectedImageBytes) { imagePath ->
+                // StorageUtil.uploadProfilePhoto(selectedImageBytes) {
                 //     FirestoreUtil.updateCurrentUser(binding.editTextName.text.toString(),
                 //         binding.editTextBio.text.toString(), imagePath)
                 // }
@@ -49,7 +53,7 @@ class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
                 FirestoreUtil.updateCurrentUser(
                     binding.editTextName.text.toString(),
                     binding.editTextBio.text.toString(),
-                    null
+                    null,
                 )
             }
             Toast.makeText(requireContext(), "saving", Toast.LENGTH_SHORT).show()
@@ -96,5 +100,4 @@ class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
         super.onDestroyView()
         _binding = null
     }
-
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountFragment.kt
@@ -12,9 +12,10 @@ import com.example.rise.databinding.FragmentMyAccountBinding
 import com.example.rise.ui.dashboardNavigation.myAccount.signInActivity.SignInActivity
 import com.example.rise.util.FirestoreUtil
 import com.firebase.ui.auth.AuthUI
-import org.koin.android.ext.android.get
 
 class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
+
+    override val viewModelClass = MyAccountBaseViewModel::class
 
     private val RC_SELECT_IMAGE = 2
     private lateinit var selectedImageBytes: ByteArray
@@ -96,7 +97,4 @@ class MyAccountFragment : BaseFragment<MyAccountBaseViewModel>() {
         _binding = null
     }
 
-    override fun createViewModel() {
-        viewModel = get()
-    }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountFragment.kt
@@ -18,8 +18,8 @@ import kotlinx.coroutines.launch
 
 class MyAccountFragment : BaseFragment() {
 
-    private val viewModel: MyAccountBaseViewModel by viewModels {
-        koinViewModelFactory(MyAccountBaseViewModel::class)
+    private val viewModel: MyAccountViewModel by viewModels {
+        koinViewModelFactory(MyAccountViewModel::class)
     }
 
     private val RC_SELECT_IMAGE = 2
@@ -85,11 +85,11 @@ class MyAccountFragment : BaseFragment() {
     private suspend fun collectEvents() {
         viewModel.events.collect { event ->
             when (event) {
-                is MyAccountBaseViewModel.Event.ShowMessage -> {
+                is MyAccountViewModel.Event.ShowMessage -> {
                     Toast.makeText(requireContext(), event.message, Toast.LENGTH_SHORT).show()
                 }
 
-                MyAccountBaseViewModel.Event.NavigateToSignIn -> {
+                MyAccountViewModel.Event.NavigateToSignIn -> {
                     val intent = Intent(requireContext(), SignInActivity::class.java).apply {
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK
                     }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-class MyAccountBaseViewModel(
+class MyAccountViewModel(
     private val repository: MyAccountRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInActivity.kt
@@ -8,9 +8,11 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.ProgressBar
+import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
 import com.example.rise.R
 import com.example.rise.baseclasses.BaseActivity
+import com.example.rise.baseclasses.koinViewModelFactory
 import com.example.rise.databinding.ActivitySignInBinding
 import com.example.rise.services.MyFirebaseMessagingService
 import com.example.rise.ui.mainActivity.MainActivity
@@ -21,9 +23,11 @@ import com.firebase.ui.auth.IdpResponse
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.messaging.FirebaseMessaging
 
-class SignInActivity : BaseActivity<SignInViewModel>() {
+class SignInActivity : BaseActivity() {
 
-    override val viewModelClass = SignInViewModel::class
+    private val viewModel: SignInViewModel by viewModels {
+        koinViewModelFactory(SignInViewModel::class)
+    }
 
     private val RC_SIGN_IN = 1
     private val signInProviders = listOf(
@@ -91,5 +95,4 @@ class SignInActivity : BaseActivity<SignInViewModel>() {
             }
         }
     }
-
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInActivity.kt
@@ -20,9 +20,10 @@ import com.firebase.ui.auth.ErrorCodes
 import com.firebase.ui.auth.IdpResponse
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.messaging.FirebaseMessaging
-import org.koin.android.ext.android.get
 
 class SignInActivity : BaseActivity<SignInViewModel>() {
+
+    override val viewModelClass = SignInViewModel::class
 
     private val RC_SIGN_IN = 1
     private val signInProviders = listOf(
@@ -91,7 +92,4 @@ class SignInActivity : BaseActivity<SignInViewModel>() {
         }
     }
 
-    override fun createViewModel() {
-        viewModel = get()
-    }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.rise.ui.dashboardNavigation.myAccount.signInActivity
 
-import com.example.rise.baseclasses.BaseViewModel
+import androidx.lifecycle.ViewModel
 
-class SignInViewModel: BaseViewModel() {
-}
+class SignInViewModel : ViewModel()

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInViewModel.kt
@@ -1,5 +1,79 @@
 package com.example.rise.ui.dashboardNavigation.myAccount.signInActivity
 
+import android.content.Intent
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.rise.data.auth.SignInIntentProvider
+import com.example.rise.data.auth.SignInRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
-class SignInViewModel : ViewModel()
+class SignInViewModel(
+    private val signInIntentProvider: SignInIntentProvider,
+    private val repository: SignInRepository,
+) : ViewModel() {
+
+    data class UiState(
+        val isLoading: Boolean = false,
+    )
+
+    sealed interface Event {
+        data class LaunchSignIn(val intent: Intent) : Event
+        data class ShowMessage(val message: String) : Event
+        object NavigateToMain : Event
+    }
+
+    sealed interface SignInFailure {
+        object Cancelled : SignInFailure
+        object NoNetwork : SignInFailure
+        data class Unknown(val message: String?) : SignInFailure
+    }
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<Event>(extraBufferCapacity = 1)
+    val events = _events.asSharedFlow()
+
+    fun onSignInClicked() {
+        val intent = signInIntentProvider.createSignInIntent()
+        _events.tryEmit(Event.LaunchSignIn(intent))
+    }
+
+    fun onSignInSuccess() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                repository.ensureUserInitialized()
+                try {
+                    val token = repository.fetchMessagingToken()
+                    if (!token.isNullOrBlank()) {
+                        repository.storeMessagingToken(token)
+                    }
+                } catch (tokenError: Exception) {
+                    _events.emit(Event.ShowMessage("Failed to register for notifications"))
+                }
+                _events.emit(Event.NavigateToMain)
+            } catch (error: Exception) {
+                _events.emit(Event.ShowMessage(error.message ?: "Failed to finish sign-in"))
+            } finally {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    fun onSignInFailure(failure: SignInFailure) {
+        val message = when (failure) {
+            SignInFailure.Cancelled -> null
+            SignInFailure.NoNetwork -> "No network"
+            is SignInFailure.Unknown -> failure.message ?: "Unknown error"
+        }
+        if (message != null) {
+            _events.tryEmit(Event.ShowMessage(message))
+        }
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatActivity.kt
@@ -2,9 +2,11 @@ package com.example.rise.ui.dashboardNavigation.people.chatActivity
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.rise.baseclasses.BaseActivity
+import com.example.rise.baseclasses.koinViewModelFactory
 import com.example.rise.databinding.ActivityChatBinding
 import com.example.rise.helpers.AppConstants
 import com.example.rise.helpers.CHAT_CHANNEL
@@ -14,12 +16,14 @@ import com.example.rise.ui.mainActivity.MainActivity
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.GroupieViewHolder
 import com.xwray.groupie.Section
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
 
-class ChatActivity : BaseActivity<ChatViewModel>() {
+class ChatActivity : BaseActivity() {
 
-    override val viewModelClass = ChatViewModel::class
+    private val viewModel: ChatViewModel by viewModels {
+        koinViewModelFactory(ChatViewModel::class)
+    }
 
     private lateinit var binding: ActivityChatBinding
     private val messagesSection = Section()

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModel.kt
@@ -1,7 +1,7 @@
 package com.example.rise.ui.dashboardNavigation.people.chatActivity
 
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rise.baseclasses.BaseViewModel
 import com.example.rise.data.chat.ChatRepository
 import com.example.rise.data.chat.ChatUser
 import com.example.rise.models.TextMessage
@@ -13,13 +13,14 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class ChatViewModel(
     private val repository: ChatRepository,
-    private val clock: Clock = Clock.systemDefaultZone()
-) : BaseViewModel() {
+    private val clock: Clock = Clock.systemDefaultZone(),
+) : ViewModel() {
 
     data class ChatUiState(
         val title: String = "",
@@ -29,14 +30,14 @@ class ChatViewModel(
         val messages: List<TextMessage> = emptyList(),
         val isLoading: Boolean = true,
         val inputEnabled: Boolean = false,
-        val errorMessage: String? = null
+        val errorMessage: String? = null,
     )
 
     sealed interface ChatEvent {
         data class LaunchSchedule(
             val message: TextMessage,
             val otherUserId: String,
-            val channelId: String
+            val channelId: String,
         ) : ChatEvent
     }
 
@@ -61,7 +62,7 @@ class ChatViewModel(
                     otherUserId = otherUserId,
                     isLoading = true,
                     errorMessage = null,
-                    inputEnabled = false
+                    inputEnabled = false,
                 )
             }
             try {
@@ -72,7 +73,7 @@ class ChatViewModel(
                         currentUser = user,
                         channelId = channelId,
                         isLoading = false,
-                        inputEnabled = true
+                        inputEnabled = true,
                     )
                 }
                 messagesJob = launch {
@@ -117,7 +118,7 @@ class ChatViewModel(
     private fun createMessage(
         text: String,
         currentUser: ChatUser,
-        otherUserId: String
+        otherUserId: String,
     ): TextMessage {
         val timestamp = Date.from(Instant.now(clock))
         return TextMessage(
@@ -125,7 +126,7 @@ class ChatViewModel(
             time = timestamp,
             senderId = currentUser.id,
             recipientId = otherUserId,
-            senderName = currentUser.displayName
+            senderName = currentUser.displayName,
         )
     }
 

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModel.kt
@@ -1,5 +1,136 @@
 package com.example.rise.ui.dashboardNavigation.people.chatActivity
 
+import androidx.lifecycle.viewModelScope
 import com.example.rise.baseclasses.BaseViewModel
+import com.example.rise.data.chat.ChatRepository
+import com.example.rise.data.chat.ChatUser
+import com.example.rise.models.TextMessage
+import java.time.Clock
+import java.time.Instant
+import java.util.Date
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
-class ChatViewModel: BaseViewModel() {}
+class ChatViewModel(
+    private val repository: ChatRepository,
+    private val clock: Clock = Clock.systemDefaultZone()
+) : BaseViewModel() {
+
+    data class ChatUiState(
+        val title: String = "",
+        val otherUserId: String? = null,
+        val channelId: String? = null,
+        val currentUser: ChatUser? = null,
+        val messages: List<TextMessage> = emptyList(),
+        val isLoading: Boolean = true,
+        val inputEnabled: Boolean = false,
+        val errorMessage: String? = null
+    )
+
+    sealed interface ChatEvent {
+        data class LaunchSchedule(
+            val message: TextMessage,
+            val otherUserId: String,
+            val channelId: String
+        ) : ChatEvent
+    }
+
+    private val _uiState = MutableStateFlow(ChatUiState())
+    val uiState = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<ChatEvent>(extraBufferCapacity = 1)
+    val events = _events.asSharedFlow()
+
+    private var messagesJob: Job? = null
+
+    fun initialiseConversation(otherUserId: String, otherUserName: String) {
+        val currentState = _uiState.value
+        if (currentState.otherUserId == otherUserId && currentState.channelId != null) {
+            return
+        }
+        messagesJob?.cancel()
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    title = otherUserName,
+                    otherUserId = otherUserId,
+                    isLoading = true,
+                    errorMessage = null,
+                    inputEnabled = false
+                )
+            }
+            try {
+                val user = repository.getCurrentUser()
+                val channelId = repository.getOrCreateChannel(otherUserId)
+                _uiState.update {
+                    it.copy(
+                        currentUser = user,
+                        channelId = channelId,
+                        isLoading = false,
+                        inputEnabled = true
+                    )
+                }
+                messagesJob = launch {
+                    repository.observeMessages(channelId).collect { messages ->
+                        _uiState.update { state -> state.copy(messages = messages) }
+                    }
+                }
+            } catch (error: Throwable) {
+                _uiState.update { it.copy(isLoading = false, errorMessage = error.message) }
+            }
+        }
+    }
+
+    fun sendMessage(text: String) {
+        val state = _uiState.value
+        val trimmed = text.trim()
+        val channelId = state.channelId
+        val currentUser = state.currentUser
+        val otherUserId = state.otherUserId
+        if (trimmed.isEmpty() || channelId == null || currentUser == null || otherUserId == null) {
+            return
+        }
+        viewModelScope.launch {
+            val message = createMessage(trimmed, currentUser, otherUserId)
+            repository.sendMessage(channelId, message)
+        }
+    }
+
+    fun scheduleMessage(text: String) {
+        val state = _uiState.value
+        val trimmed = text.trim()
+        val channelId = state.channelId
+        val currentUser = state.currentUser
+        val otherUserId = state.otherUserId
+        if (trimmed.isEmpty() || channelId == null || currentUser == null || otherUserId == null) {
+            return
+        }
+        val message = createMessage(trimmed, currentUser, otherUserId)
+        _events.tryEmit(ChatEvent.LaunchSchedule(message, otherUserId, channelId))
+    }
+
+    private fun createMessage(
+        text: String,
+        currentUser: ChatUser,
+        otherUserId: String
+    ): TextMessage {
+        val timestamp = Date.from(Instant.now(clock))
+        return TextMessage(
+            text = text,
+            time = timestamp,
+            senderId = currentUser.id,
+            recipientId = otherUserId,
+            senderName = currentUser.displayName
+        )
+    }
+
+    override fun onCleared() {
+        messagesJob?.cancel()
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleFragment.kt
@@ -5,9 +5,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.rise.baseclasses.BaseFragment
+import com.example.rise.baseclasses.koinViewModelFactory
 import com.example.rise.databinding.FragmentPeopleBinding
 import com.example.rise.helpers.AppConstants
 import com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatActivity
@@ -17,9 +19,11 @@ import com.xwray.groupie.Section
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 
-class PeopleFragment : BaseFragment<PeopleViewModel>() {
+class PeopleFragment : BaseFragment() {
 
-    override val viewModelClass = PeopleViewModel::class
+    private val viewModel: PeopleViewModel by viewModels {
+        koinViewModelFactory(PeopleViewModel::class)
+    }
 
     private var _binding: FragmentPeopleBinding? = null
     private val binding get() = _binding!!
@@ -31,7 +35,7 @@ class PeopleFragment : BaseFragment<PeopleViewModel>() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentPeopleBinding.inflate(inflater, container, false)
         return binding.root
@@ -66,10 +70,10 @@ class PeopleFragment : BaseFragment<PeopleViewModel>() {
                             summary.name,
                             summary.bio,
                             summary.profilePicturePath,
-                            mutableListOf()
+                            mutableListOf(),
                         ),
                         userId = summary.id,
-                        context = requireContext()
+                        context = requireContext(),
                     )
                 }
                 peopleById = state.people.associateBy { it.id }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleFragment.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleFragment.kt
@@ -5,28 +5,28 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.rise.baseclasses.BaseFragment
 import com.example.rise.databinding.FragmentPeopleBinding
 import com.example.rise.helpers.AppConstants
-import com.example.rise.item.PersonItem
 import com.example.rise.ui.dashboardNavigation.people.chatActivity.ChatActivity
-import com.example.rise.util.FirestoreUtil
-import com.google.firebase.firestore.ListenerRegistration
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.GroupieViewHolder
-import com.xwray.groupie.Item
-import com.xwray.groupie.OnItemClickListener
 import com.xwray.groupie.Section
-import org.koin.android.ext.android.get
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
 
 class PeopleFragment : BaseFragment<PeopleViewModel>() {
 
-    private lateinit var userListenerRegistration: ListenerRegistration
-    private var shouldInitRecyclerView = true
-    private lateinit var peopleSection: Section
+    override val viewModelClass = PeopleViewModel::class
+
     private var _binding: FragmentPeopleBinding? = null
     private val binding get() = _binding!!
+
+    private val peopleSection = Section()
+    private val adapter = GroupAdapter<GroupieViewHolder>().apply { add(peopleSection) }
+    private var peopleById: Map<String, com.example.rise.data.people.PersonSummary> = emptyMap()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -34,51 +34,70 @@ class PeopleFragment : BaseFragment<PeopleViewModel>() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentPeopleBinding.inflate(inflater, container, false)
-        userListenerRegistration = FirestoreUtil.addUsersListener(requireActivity(), this::updateRecyclerView)
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+        observeState()
+        observeEvents()
+        viewModel.start()
+    }
+
+    private fun setupRecyclerView() {
+        binding.recyclerViewPeople.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = this@PeopleFragment.adapter
+        }
+        adapter.setOnItemClickListener { item, _ ->
+            val personItem = item as? com.example.rise.item.PersonItem ?: return@setOnItemClickListener
+            val summary = peopleById[personItem.userId] ?: return@setOnItemClickListener
+            viewModel.onPersonSelected(summary)
+        }
+    }
+
+    private fun observeState() {
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            viewModel.uiState.collectLatest { state ->
+                val items = state.people.map { summary ->
+                    com.example.rise.item.PersonItem(
+                        person = com.example.rise.models.User(
+                            summary.name,
+                            summary.bio,
+                            summary.profilePicturePath,
+                            mutableListOf()
+                        ),
+                        userId = summary.id,
+                        context = requireContext()
+                    )
+                }
+                peopleById = state.people.associateBy { it.id }
+                peopleSection.update(items)
+            }
+        }
+    }
+
+    private fun observeEvents() {
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is PeopleViewModel.PeopleEvent.OpenChat -> openChat(event)
+                }
+            }
+        }
+    }
+
+    private fun openChat(event: PeopleViewModel.PeopleEvent.OpenChat) {
+        val intent = Intent(context, ChatActivity::class.java).apply {
+            putExtra(AppConstants.USER_NAME, event.personName)
+            putExtra(AppConstants.USER_ID, event.personId)
+        }
+        startActivity(intent)
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        FirestoreUtil.removeListener(userListenerRegistration)
-        shouldInitRecyclerView = true
         _binding = null
-    }
-
-    private fun updateRecyclerView(items: List<Item<*>>) {
-
-        fun init() {
-            binding.recyclerViewPeople.apply {
-                layoutManager = LinearLayoutManager(requireContext())
-                adapter = GroupAdapter<GroupieViewHolder>().apply {
-                    peopleSection = Section(items)
-                    add(peopleSection)
-                    setOnItemClickListener(onItemClick)
-                }
-            }
-            shouldInitRecyclerView = false
-        }
-
-        fun updateItems() = peopleSection.update(items)
-
-        if (shouldInitRecyclerView) {
-            init()
-        } else {
-            updateItems()
-        }
-    }
-
-    private val onItemClick = OnItemClickListener { item, _ ->
-        if (item is PersonItem) {
-            val intent = Intent(context, ChatActivity::class.java).apply {
-                putExtra(AppConstants.USER_NAME, item.person.name)
-                putExtra(AppConstants.USER_ID, item.userId)
-            }
-            startActivity(intent)
-        }
-    }
-
-    override fun createViewModel() {
-        viewModel = get()
     }
 }

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModel.kt
@@ -1,5 +1,67 @@
 package com.example.rise.ui.dashboardNavigation.people.peopleFragment
 
+import androidx.lifecycle.viewModelScope
 import com.example.rise.baseclasses.BaseViewModel
+import com.example.rise.data.people.PeopleRepository
+import com.example.rise.data.people.PersonSummary
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
-class PeopleViewModel: BaseViewModel() {}
+class PeopleViewModel(
+    private val repository: PeopleRepository
+) : BaseViewModel() {
+
+    data class PeopleUiState(
+        val people: List<PersonSummary> = emptyList(),
+        val isLoading: Boolean = true,
+        val errorMessage: String? = null
+    )
+
+    sealed interface PeopleEvent {
+        data class OpenChat(val personId: String, val personName: String) : PeopleEvent
+    }
+
+    private val _uiState = MutableStateFlow(PeopleUiState())
+    val uiState = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<PeopleEvent>(extraBufferCapacity = 1)
+    val events = _events.asSharedFlow()
+
+    private var observeJob: Job? = null
+
+    fun start() {
+        if (observeJob != null) return
+        observeJob = viewModelScope.launch {
+            repository.observePeople()
+                .onStart { _uiState.update { it.copy(isLoading = true, errorMessage = null) } }
+                .catch { error ->
+                    _uiState.update { it.copy(isLoading = false, errorMessage = error.message) }
+                }
+                .collect { people ->
+                    _uiState.update {
+                        it.copy(
+                            people = people,
+                            isLoading = false,
+                            errorMessage = null
+                        )
+                    }
+                }
+        }
+    }
+
+    fun onPersonSelected(person: PersonSummary) {
+        _events.tryEmit(PeopleEvent.OpenChat(person.id, person.name))
+    }
+
+    override fun onCleared() {
+        observeJob?.cancel()
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModel.kt
@@ -1,7 +1,7 @@
 package com.example.rise.ui.dashboardNavigation.people.peopleFragment
 
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rise.baseclasses.BaseViewModel
 import com.example.rise.data.people.PeopleRepository
 import com.example.rise.data.people.PersonSummary
 import kotlinx.coroutines.Job
@@ -10,18 +10,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class PeopleViewModel(
-    private val repository: PeopleRepository
-) : BaseViewModel() {
+    private val repository: PeopleRepository,
+) : ViewModel() {
 
     data class PeopleUiState(
         val people: List<PersonSummary> = emptyList(),
         val isLoading: Boolean = true,
-        val errorMessage: String? = null
+        val errorMessage: String? = null,
     )
 
     sealed interface PeopleEvent {
@@ -49,7 +50,7 @@ class PeopleViewModel(
                         it.copy(
                             people = people,
                             isLoading = false,
-                            errorMessage = null
+                            errorMessage = null,
                         )
                     }
                 }

--- a/app/src/main/java/com/example/rise/ui/mainActivity/MainActivity.kt
+++ b/app/src/main/java/com/example/rise/ui/mainActivity/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.rise.ui.mainActivity
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
@@ -9,13 +10,16 @@ import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.example.rise.R
 import com.example.rise.baseclasses.BaseActivity
+import com.example.rise.baseclasses.koinViewModelFactory
 import com.example.rise.ui.mainActivity.MainActivityViewModel.MainActivityEvent
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.coroutines.flow.collect
 
-class MainActivity : BaseActivity<MainActivityViewModel>() {
+class MainActivity : BaseActivity() {
 
-    override val viewModelClass = MainActivityViewModel::class
+    private val viewModel: MainActivityViewModel by viewModels {
+        koinViewModelFactory(MainActivityViewModel::class)
+    }
 
     private val signInLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()

--- a/app/src/main/java/com/example/rise/ui/mainActivity/MainActivityViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/mainActivity/MainActivityViewModel.kt
@@ -1,7 +1,7 @@
 package com.example.rise.ui.mainActivity
 
 import android.app.Activity
-import com.example.rise.baseclasses.BaseViewModel
+import androidx.lifecycle.ViewModel
 import com.example.rise.data.auth.AuthStateProvider
 import com.example.rise.data.auth.SignInIntentProvider
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -12,12 +12,12 @@ import kotlinx.coroutines.flow.update
 
 class MainActivityViewModel(
     private val authStateProvider: AuthStateProvider,
-    private val signInIntentProvider: SignInIntentProvider
-) : BaseViewModel() {
+    private val signInIntentProvider: SignInIntentProvider,
+) : ViewModel() {
 
     data class MainActivityUiState(
         val isSigningIn: Boolean = false,
-        val isUserSignedIn: Boolean = false
+        val isUserSignedIn: Boolean = false,
     )
 
     sealed interface MainActivityEvent {
@@ -25,7 +25,7 @@ class MainActivityViewModel(
     }
 
     private val _uiState = MutableStateFlow(
-        MainActivityUiState(isUserSignedIn = authStateProvider.isSignedIn())
+        MainActivityUiState(isUserSignedIn = authStateProvider.isSignedIn()),
     )
     val uiState = _uiState.asStateFlow()
 

--- a/app/src/main/java/com/example/rise/ui/mainActivity/MainActivityViewModel.kt
+++ b/app/src/main/java/com/example/rise/ui/mainActivity/MainActivityViewModel.kt
@@ -1,7 +1,63 @@
 package com.example.rise.ui.mainActivity
 
+import android.app.Activity
 import com.example.rise.baseclasses.BaseViewModel
+import com.example.rise.data.auth.AuthStateProvider
+import com.example.rise.data.auth.SignInIntentProvider
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
-class MainActivityViewModel() : BaseViewModel(){
-    var mSignIn : Boolean = false
+class MainActivityViewModel(
+    private val authStateProvider: AuthStateProvider,
+    private val signInIntentProvider: SignInIntentProvider
+) : BaseViewModel() {
+
+    data class MainActivityUiState(
+        val isSigningIn: Boolean = false,
+        val isUserSignedIn: Boolean = false
+    )
+
+    sealed interface MainActivityEvent {
+        data class LaunchSignIn(val intent: android.content.Intent) : MainActivityEvent
+    }
+
+    private val _uiState = MutableStateFlow(
+        MainActivityUiState(isUserSignedIn = authStateProvider.isSignedIn())
+    )
+    val uiState = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<MainActivityEvent>(extraBufferCapacity = 1)
+    val events = _events.asSharedFlow()
+
+    fun onStart() {
+        ensureSignedIn()
+    }
+
+    fun onSignInResult(resultCode: Int) {
+        _uiState.update { it.copy(isSigningIn = false) }
+        if (resultCode == Activity.RESULT_OK) {
+            _uiState.update { it.copy(isUserSignedIn = true) }
+        } else {
+            ensureSignedIn()
+        }
+    }
+
+    private fun ensureSignedIn() {
+        val signedIn = authStateProvider.isSignedIn()
+        _uiState.update { it.copy(isUserSignedIn = signedIn) }
+        if (!signedIn && !_uiState.value.isSigningIn) {
+            launchSignIn()
+        }
+    }
+
+    private fun launchSignIn() {
+        val intent = signInIntentProvider.createSignInIntent()
+        val emitted = _events.tryEmit(MainActivityEvent.LaunchSignIn(intent))
+        if (emitted) {
+            _uiState.update { it.copy(isSigningIn = true) }
+        }
+    }
 }

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -41,4 +41,14 @@
             app:layout_constraintTop_toBottomOf="@+id/imageView"
             app:layout_constraintVertical_bias="0.257" />
 
+    <ProgressBar
+            android:id="@+id/progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/example/rise/ui/SplashActivityViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/SplashActivityViewModelTest.kt
@@ -1,0 +1,46 @@
+package com.example.rise.ui
+
+import app.cash.turbine.test
+import com.example.rise.data.auth.AuthStateProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.Assert.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SplashActivityViewModelTest {
+
+    @Test
+    fun `navigates to main when user signed in`() = runTest {
+        val viewModel = SplashActivityViewModel(FakeAuthStateProvider(isSignedIn = true))
+
+        viewModel.events.test {
+            viewModel.determineDestination()
+
+            val event = awaitItem()
+            assertTrue(event is SplashActivityViewModel.NavigationEvent.ToMain)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `navigates to sign-in when user signed out`() = runTest {
+        val viewModel = SplashActivityViewModel(FakeAuthStateProvider(isSignedIn = false))
+
+        viewModel.events.test {
+            viewModel.determineDestination()
+
+            val event = awaitItem()
+            assertTrue(event is SplashActivityViewModel.NavigationEvent.ToSignIn)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class FakeAuthStateProvider(private val isSignedIn: Boolean) : AuthStateProvider {
+        override fun isSignedIn(): Boolean = isSignedIn
+
+        override fun currentUserId(): String? = if (isSignedIn) "id" else null
+
+        override fun currentUserDisplayName(): String? = if (isSignedIn) "name" else null
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/alarm/ReminderViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/alarm/ReminderViewModelTest.kt
@@ -1,0 +1,199 @@
+package com.example.rise.ui.alarm
+
+import app.cash.turbine.test
+import com.example.rise.data.alarm.ReminderPreferences
+import com.example.rise.models.Alarm
+import com.example.rise.util.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReminderViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val defaultAlarm = Alarm(label = "", soundUri = "content://alarm")
+
+    @Test
+    fun `initialize with alarm populates ui state`() = runTest {
+        val preferences = FakeReminderPreferences(increaseVolumeGradually = true)
+        val viewModel = ReminderViewModel(preferences)
+
+        viewModel.initialize(
+            ReminderViewModel.Args(
+                alarm = defaultAlarm.copy(label = "Morning"),
+                isAlarmReminder = true,
+                alarmLabelFallback = "Alarm",
+                timerLabel = "Timer",
+                timerExpiredText = "Expired",
+                formattedTimeProvider = { "10:00" },
+            ),
+        )
+
+        val state = viewModel.uiState.value
+        assertEquals("Morning", state.title)
+        assertEquals("10:00", state.message)
+        assertTrue(state.isAlarmReminder)
+        assertTrue(state.increaseVolumeGradually)
+        assertEquals(0.1f, state.currentVolume, 0.001f)
+    }
+
+    @Test
+    fun `initialize without alarm uses timer strings`() = runTest {
+        val preferences = FakeReminderPreferences()
+        val viewModel = ReminderViewModel(preferences)
+
+        viewModel.initialize(
+            ReminderViewModel.Args(
+                alarm = null,
+                isAlarmReminder = false,
+                alarmLabelFallback = "Alarm",
+                timerLabel = "Timer",
+                timerExpiredText = "Expired",
+                formattedTimeProvider = { "Ignored" },
+            ),
+        )
+
+        val state = viewModel.uiState.value
+        assertEquals("Timer", state.title)
+        assertEquals("Expired", state.message)
+        assertFalse(state.isAlarmReminder)
+        assertEquals(1f, state.currentVolume, 0.001f)
+    }
+
+    @Test
+    fun `auto finish emits finish event after duration`() = runTest {
+        val preferences = FakeReminderPreferences(alarmMaxReminderSeconds = 1)
+        val viewModel = ReminderViewModel(preferences)
+
+        viewModel.initialize(
+            ReminderViewModel.Args(
+                alarm = defaultAlarm,
+                isAlarmReminder = true,
+                alarmLabelFallback = "Alarm",
+                timerLabel = "Timer",
+                timerExpiredText = "Expired",
+                formattedTimeProvider = { "10:00" },
+            ),
+        )
+
+        viewModel.events.test {
+            advanceTimeBy(1_000)
+            assertEquals(ReminderViewModel.Event.Finish, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `snooze requested with same snooze emits schedule event`() = runTest {
+        val preferences = FakeReminderPreferences(useSameSnooze = true, snoozeMinutes = 5)
+        val viewModel = ReminderViewModel(preferences)
+
+        viewModel.initialize(
+            ReminderViewModel.Args(
+                alarm = defaultAlarm,
+                isAlarmReminder = true,
+                alarmLabelFallback = "Alarm",
+                timerLabel = "Timer",
+                timerExpiredText = "Expired",
+                formattedTimeProvider = { "10:00" },
+            ),
+        )
+
+        viewModel.events.test {
+            viewModel.onSnoozeRequested()
+            val event = awaitItem() as ReminderViewModel.Event.ScheduleSnooze
+            assertEquals(5 * 60, event.seconds)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `snooze requested without same snooze shows picker`() = runTest {
+        val preferences = FakeReminderPreferences(useSameSnooze = false, snoozeMinutes = 3)
+        val viewModel = ReminderViewModel(preferences)
+
+        viewModel.initialize(
+            ReminderViewModel.Args(
+                alarm = defaultAlarm,
+                isAlarmReminder = true,
+                alarmLabelFallback = "Alarm",
+                timerLabel = "Timer",
+                timerExpiredText = "Expired",
+                formattedTimeProvider = { "10:00" },
+            ),
+        )
+
+        viewModel.events.test {
+            viewModel.onSnoozeRequested()
+            val event = awaitItem() as ReminderViewModel.Event.ShowSnoozePicker
+            assertEquals(3 * 60, event.defaultSeconds)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `snooze duration selection stores preference and schedules`() = runTest {
+        val preferences = FakeReminderPreferences(useSameSnooze = false, snoozeMinutes = 3)
+        val viewModel = ReminderViewModel(preferences)
+
+        viewModel.initialize(
+            ReminderViewModel.Args(
+                alarm = defaultAlarm,
+                isAlarmReminder = true,
+                alarmLabelFallback = "Alarm",
+                timerLabel = "Timer",
+                timerExpiredText = "Expired",
+                formattedTimeProvider = { "10:00" },
+            ),
+        )
+
+        viewModel.events.test {
+            viewModel.onSnoozeDurationSelected(600)
+            val event = awaitItem() as ReminderViewModel.Event.ScheduleSnooze
+            assertEquals(600, event.seconds)
+            assertEquals(10, preferences.snoozeMinutes)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `volume increase emits updates until max`() = runTest {
+        val preferences = FakeReminderPreferences(increaseVolumeGradually = true)
+        val viewModel = ReminderViewModel(preferences)
+
+        viewModel.initialize(
+            ReminderViewModel.Args(
+                alarm = defaultAlarm,
+                isAlarmReminder = true,
+                alarmLabelFallback = "Alarm",
+                timerLabel = "Timer",
+                timerExpiredText = "Expired",
+                formattedTimeProvider = { "10:00" },
+            ),
+        )
+
+        viewModel.events.test {
+            advanceTimeBy(3_000)
+            val update = awaitItem() as ReminderViewModel.Event.UpdateVolume
+            assertEquals(0.2f, update.volume, 0.001f)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class FakeReminderPreferences(
+        override val alarmMaxReminderSeconds: Int = 30,
+        override val timerMaxReminderSeconds: Int = 60,
+        override val increaseVolumeGradually: Boolean = false,
+        override val useSameSnooze: Boolean = true,
+        override var snoozeMinutes: Int = 5,
+        override val timerSoundUri: String? = "content://timer",
+    ) : ReminderPreferences
+}

--- a/app/src/test/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/dashboardNavigation/dashboard/DashboardViewModelTest.kt
@@ -1,0 +1,90 @@
+package com.example.rise.ui.dashboardNavigation.dashboard
+
+import app.cash.turbine.test
+import com.example.rise.data.dashboard.AlarmRepository
+import com.example.rise.models.Alarm
+import com.example.rise.models.TextMessage
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.Query
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import com.example.rise.util.MainDispatcherRule
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DashboardViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val query: Query = mockk(relaxed = true)
+    private val repository = FakeAlarmRepository(query)
+    private val firebaseUser: FirebaseUser = mockk {
+        every { uid } returns "self"
+        every { displayName } returns "Alice"
+    }
+    private val auth: FirebaseAuth = mockk {
+        every { currentUser } returns firebaseUser
+    }
+    private val clock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC)
+
+    @org.junit.Test
+    fun `initialise configures query and active user`() {
+        val viewModel = DashboardViewModel(repository, auth, clock)
+
+        viewModel.initialise(byBottomNavigation = false, explicitUserId = "other", chatChannel = "channel", message = null)
+
+        val state = viewModel.uiState.value
+        assertEquals("other", state.activeUserId)
+        assertEquals(query, state.alarmQuery)
+        assertEquals("channel", state.chatChannel)
+        assertNull(state.pendingMessage)
+        assertEquals(false, state.isLoading)
+    }
+
+    @org.junit.Test
+    fun `createAlarm saves alarm and emits schedule event when message provided`() = runTest {
+        val viewModel = DashboardViewModel(repository, auth, clock)
+        val message = TextMessage(
+            text = "Hello",
+            time = Date(),
+            senderId = "self",
+            recipientId = "other",
+            senderName = "Alice"
+        )
+        viewModel.initialise(byBottomNavigation = false, explicitUserId = "other", chatChannel = "channel", message = message)
+
+        viewModel.events.test {
+            viewModel.createAlarm(timeInMillis = 1234L)
+            advanceUntilIdle()
+            val event = awaitItem()
+            assertTrue(event is DashboardViewModel.DashboardEvent.ScheduleAlarm)
+            assertEquals(1, repository.saved.size)
+            val alarm = repository.saved.first()
+            assertEquals(1234L, alarm.timeInMiliseconds)
+            assertEquals("channel", alarm.chatChannel)
+            assertEquals(message, alarm.messsage)
+            assertEquals(Instant.now(clock).toEpochMilli().toInt(), alarm.idTimeStamp)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class FakeAlarmRepository(private val query: Query) : AlarmRepository {
+        val saved = mutableListOf<Alarm>()
+        override fun alarmsQuery(userId: String): Query = query
+        override suspend fun saveAlarm(userId: String, alarm: Alarm) {
+            saved += alarm
+        }
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountBaseViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountBaseViewModelTest.kt
@@ -1,0 +1,89 @@
+package com.example.rise.ui.dashboardNavigation.myAccount
+
+import app.cash.turbine.test
+import com.example.rise.data.myaccount.MyAccountRepository
+import com.example.rise.models.User
+import com.example.rise.util.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MyAccountBaseViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `loadProfile populates ui state`() = runTest {
+        val repository = FakeMyAccountRepository()
+        val viewModel = MyAccountBaseViewModel(repository)
+
+        viewModel.loadProfile()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(repository.user.name, state.name)
+        assertEquals(repository.user.bio, state.bio)
+        assertEquals(false, state.isLoading)
+    }
+
+    @Test
+    fun `updateProfile updates repository and emits toast`() = runTest {
+        val repository = FakeMyAccountRepository()
+        val viewModel = MyAccountBaseViewModel(repository)
+
+        viewModel.events.test {
+            viewModel.updateProfile("New Name", "New Bio")
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals("New Name", state.name)
+            assertEquals("New Bio", state.bio)
+            assertEquals(listOf("New Name" to "New Bio"), repository.updateCalls)
+
+            val event = awaitItem()
+            assertTrue(event is MyAccountBaseViewModel.Event.ShowMessage)
+            val messageEvent = event as MyAccountBaseViewModel.Event.ShowMessage
+            assertEquals("saving", messageEvent.message)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `signOut emits navigation event`() = runTest {
+        val repository = FakeMyAccountRepository()
+        val viewModel = MyAccountBaseViewModel(repository)
+
+        viewModel.events.test {
+            viewModel.signOut()
+            advanceUntilIdle()
+
+            val event = awaitItem()
+            assertTrue(event is MyAccountBaseViewModel.Event.NavigateToSignIn)
+            assertEquals(1, repository.signOutCalls)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class FakeMyAccountRepository : MyAccountRepository {
+        var user = User(name = "Jane", bio = "Bio", profilePicturePath = null, registrationTokens = mutableListOf())
+        val updateCalls = mutableListOf<Pair<String, String>>()
+        var signOutCalls = 0
+
+        override suspend fun fetchCurrentUser(): User = user
+
+        override suspend fun updateCurrentUser(name: String, bio: String) {
+            updateCalls += name to bio
+            user = user.copy(name = name, bio = bio)
+        }
+
+        override suspend fun signOut() {
+            signOutCalls++
+        }
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/dashboardNavigation/myAccount/MyAccountViewModelTest.kt
@@ -13,7 +13,7 @@ import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class MyAccountBaseViewModelTest {
+class MyAccountViewModelTest {
 
     @get:Rule
     val dispatcherRule = MainDispatcherRule()
@@ -21,7 +21,7 @@ class MyAccountBaseViewModelTest {
     @Test
     fun `loadProfile populates ui state`() = runTest {
         val repository = FakeMyAccountRepository()
-        val viewModel = MyAccountBaseViewModel(repository)
+        val viewModel = MyAccountViewModel(repository)
 
         viewModel.loadProfile()
         advanceUntilIdle()
@@ -35,7 +35,7 @@ class MyAccountBaseViewModelTest {
     @Test
     fun `updateProfile updates repository and emits toast`() = runTest {
         val repository = FakeMyAccountRepository()
-        val viewModel = MyAccountBaseViewModel(repository)
+        val viewModel = MyAccountViewModel(repository)
 
         viewModel.events.test {
             viewModel.updateProfile("New Name", "New Bio")
@@ -47,8 +47,8 @@ class MyAccountBaseViewModelTest {
             assertEquals(listOf("New Name" to "New Bio"), repository.updateCalls)
 
             val event = awaitItem()
-            assertTrue(event is MyAccountBaseViewModel.Event.ShowMessage)
-            val messageEvent = event as MyAccountBaseViewModel.Event.ShowMessage
+            assertTrue(event is MyAccountViewModel.Event.ShowMessage)
+            val messageEvent = event as MyAccountViewModel.Event.ShowMessage
             assertEquals("saving", messageEvent.message)
             cancelAndIgnoreRemainingEvents()
         }
@@ -57,14 +57,14 @@ class MyAccountBaseViewModelTest {
     @Test
     fun `signOut emits navigation event`() = runTest {
         val repository = FakeMyAccountRepository()
-        val viewModel = MyAccountBaseViewModel(repository)
+        val viewModel = MyAccountViewModel(repository)
 
         viewModel.events.test {
             viewModel.signOut()
             advanceUntilIdle()
 
             val event = awaitItem()
-            assertTrue(event is MyAccountBaseViewModel.Event.NavigateToSignIn)
+            assertTrue(event is MyAccountViewModel.Event.NavigateToSignIn)
             assertEquals(1, repository.signOutCalls)
             cancelAndIgnoreRemainingEvents()
         }

--- a/app/src/test/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/dashboardNavigation/myAccount/signInActivity/SignInViewModelTest.kt
@@ -1,0 +1,122 @@
+package com.example.rise.ui.dashboardNavigation.myAccount.signInActivity
+
+import android.content.Intent
+import app.cash.turbine.test
+import app.cash.turbine.testIn
+import app.cash.turbine.turbineScope
+import com.example.rise.data.auth.SignInIntentProvider
+import com.example.rise.data.auth.SignInRepository
+import com.example.rise.util.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SignInViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val intent = Intent("test-action")
+    private val intentProvider = SignInIntentProvider { intent }
+
+    @Test
+    fun `onSignInClicked emits launch event`() = runTest {
+        val repository = FakeSignInRepository()
+        val viewModel = SignInViewModel(intentProvider, repository)
+
+        viewModel.events.test {
+            viewModel.onSignInClicked()
+            val event = awaitItem() as SignInViewModel.Event.LaunchSignIn
+            assertEquals(intent, event.intent)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onSignInSuccess toggles loading state and navigates to main`() = runTest {
+        val repository = FakeSignInRepository()
+        val viewModel = SignInViewModel(intentProvider, repository)
+
+        turbineScope {
+            val stateTurbine = viewModel.uiState.testIn(this)
+            val eventTurbine = viewModel.events.testIn(this)
+
+            assertFalse(stateTurbine.awaitItem().isLoading)
+            viewModel.onSignInSuccess()
+            assertTrue(stateTurbine.awaitItem().isLoading)
+            assertFalse(stateTurbine.awaitItem().isLoading)
+            assertEquals(SignInViewModel.Event.NavigateToMain, eventTurbine.awaitItem())
+            assertEquals("token", repository.storedToken)
+
+            stateTurbine.cancel()
+            eventTurbine.cancel()
+        }
+    }
+
+    @Test
+    fun `onSignInSuccess reports failure when initialization fails`() = runTest {
+        val repository = FakeSignInRepository(ensureUserInitializedError = IllegalStateException("boom"))
+        val viewModel = SignInViewModel(intentProvider, repository)
+
+        viewModel.events.test {
+            viewModel.onSignInSuccess()
+            val message = awaitItem() as SignInViewModel.Event.ShowMessage
+            assertEquals("boom", message.message)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onSignInFailure emits snackbar message for no network`() = runTest {
+        val repository = FakeSignInRepository()
+        val viewModel = SignInViewModel(intentProvider, repository)
+
+        viewModel.events.test {
+            viewModel.onSignInFailure(SignInViewModel.SignInFailure.NoNetwork)
+            val message = awaitItem() as SignInViewModel.Event.ShowMessage
+            assertEquals("No network", message.message)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onSignInSuccess shows warning when token registration fails`() = runTest {
+        val repository = FakeSignInRepository(tokenError = IllegalArgumentException("token failure"))
+        val viewModel = SignInViewModel(intentProvider, repository)
+
+        viewModel.events.test {
+            viewModel.onSignInSuccess()
+            val showMessage = awaitItem() as SignInViewModel.Event.ShowMessage
+            assertEquals("Failed to register for notifications", showMessage.message)
+            assertEquals(SignInViewModel.Event.NavigateToMain, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class FakeSignInRepository(
+        private val ensureUserInitializedError: Throwable? = null,
+        private val token: String? = "token",
+        private val tokenError: Throwable? = null,
+    ) : SignInRepository {
+
+        var storedToken: String? = null
+
+        override suspend fun ensureUserInitialized() {
+            ensureUserInitializedError?.let { throw it }
+        }
+
+        override suspend fun fetchMessagingToken(): String? {
+            tokenError?.let { throw it }
+            return token
+        }
+
+        override suspend fun storeMessagingToken(token: String) {
+            storedToken = token
+        }
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/dashboardNavigation/people/chatActivity/ChatViewModelTest.kt
@@ -1,0 +1,107 @@
+package com.example.rise.ui.dashboardNavigation.people.chatActivity
+
+import app.cash.turbine.test
+import com.example.rise.data.chat.ChatRepository
+import com.example.rise.data.chat.ChatUser
+import com.example.rise.models.TextMessage
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import com.example.rise.util.MainDispatcherRule
+import kotlinx.coroutines.test.advanceUntilIdle
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val fixedClock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC)
+
+    @org.junit.Test
+    fun `initialiseConversation loads user, channel, and messages`() = runTest {
+        val repository = FakeChatRepository().apply {
+            messages.tryEmit(emptyList())
+        }
+        val viewModel = ChatViewModel(repository, fixedClock)
+
+        viewModel.initialiseConversation(otherUserId = "other", otherUserName = "Bob")
+        advanceUntilIdle()
+        val initialState = viewModel.uiState.value
+        assertTrue("Expected input enabled. State: $initialState", initialState.inputEnabled)
+        assertEquals("Expected title to update. State: $initialState", "Bob", initialState.title)
+        assertEquals(
+            "Expected channel id to match. State: $initialState",
+            repository.channelId,
+            initialState.channelId,
+        )
+
+        val newMessages = listOf(repository.sampleMessage)
+        repository.messages.tryEmit(newMessages)
+        advanceUntilIdle()
+
+        assertEquals(newMessages, viewModel.uiState.value.messages)
+    }
+
+    @org.junit.Test
+    fun `sendMessage delegates to repository`() = runTest {
+        val repository = FakeChatRepository().apply { messages.tryEmit(emptyList()) }
+        val viewModel = ChatViewModel(repository, fixedClock)
+
+        viewModel.initialiseConversation("other", "Bob")
+        advanceUntilIdle()
+        viewModel.sendMessage("Hello")
+        advanceUntilIdle()
+
+        assertEquals(1, repository.sentMessages.size)
+        val sent = repository.sentMessages.first()
+        assertEquals("Hello", sent.text)
+        assertEquals("self", sent.senderId)
+        assertEquals("other", sent.recipientId)
+    }
+
+    @org.junit.Test
+    fun `scheduleMessage emits navigation event`() = runTest {
+        val repository = FakeChatRepository().apply { messages.tryEmit(emptyList()) }
+        val viewModel = ChatViewModel(repository, fixedClock)
+        viewModel.initialiseConversation("other", "Bob")
+        advanceUntilIdle()
+
+        viewModel.events.test {
+            viewModel.scheduleMessage("Later")
+            val event = awaitItem()
+            assertTrue(event is ChatViewModel.ChatEvent.LaunchSchedule)
+            val schedule = event as ChatViewModel.ChatEvent.LaunchSchedule
+            assertEquals("other", schedule.otherUserId)
+            assertEquals(repository.channelId, schedule.channelId)
+            assertEquals("Later", schedule.message.text)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class FakeChatRepository : ChatRepository {
+        val sampleMessage = TextMessage(
+            text = "Hi",
+            time = Date.from(Instant.parse("2024-01-01T00:00:00Z")),
+            senderId = "other",
+            recipientId = "self",
+            senderName = "Bob"
+        )
+        val messages = MutableSharedFlow<List<TextMessage>>(replay = 1)
+        val sentMessages = mutableListOf<TextMessage>()
+        val channelId = "channel-123"
+        override suspend fun getCurrentUser(): ChatUser = ChatUser(id = "self", displayName = "Alice")
+        override suspend fun getOrCreateChannel(otherUserId: String): String = channelId
+        override fun observeMessages(channelId: String) = messages
+        override suspend fun sendMessage(channelId: String, message: TextMessage) {
+            sentMessages += message
+        }
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/dashboardNavigation/people/peopleFragment/PeopleViewModelTest.kt
@@ -1,0 +1,67 @@
+package com.example.rise.ui.dashboardNavigation.people.peopleFragment
+
+import app.cash.turbine.test
+import com.example.rise.data.people.PeopleRepository
+import com.example.rise.data.people.PersonSummary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import com.example.rise.util.MainDispatcherRule
+import kotlinx.coroutines.test.advanceUntilIdle
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PeopleViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    @org.junit.Test
+    fun `start observes people and updates state`() = runTest {
+        val repository = FakePeopleRepository()
+        val viewModel = PeopleViewModel(repository)
+
+        viewModel.start()
+        advanceUntilIdle()
+        assertTrue("Expected loading before people emission", viewModel.uiState.value.isLoading)
+
+        val entries = listOf(
+            PersonSummary(id = "a", name = "Alice", bio = "Bio", profilePicturePath = null)
+        )
+        repository.people.tryEmit(entries)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(entries, state.people)
+        assertEquals(false, state.isLoading)
+    }
+
+    @org.junit.Test
+    fun `onPersonSelected emits navigation event`() = runTest {
+        val repository = FakePeopleRepository()
+        val viewModel = PeopleViewModel(repository)
+        val summary = PersonSummary(id = "a", name = "Alice", bio = "Bio", profilePicturePath = null)
+
+        viewModel.start()
+        advanceUntilIdle()
+        repository.people.tryEmit(listOf(summary))
+        advanceUntilIdle()
+
+        viewModel.events.test {
+            viewModel.onPersonSelected(summary)
+            val event = awaitItem()
+            assertTrue(event is PeopleViewModel.PeopleEvent.OpenChat)
+            val openChat = event as PeopleViewModel.PeopleEvent.OpenChat
+            assertEquals(summary.id, openChat.personId)
+            assertEquals(summary.name, openChat.personName)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class FakePeopleRepository : PeopleRepository {
+        val people = MutableSharedFlow<List<PersonSummary>>(replay = 1)
+        override fun observePeople() = people
+    }
+}

--- a/app/src/test/java/com/example/rise/ui/mainActivity/MainActivityViewModelTest.kt
+++ b/app/src/test/java/com/example/rise/ui/mainActivity/MainActivityViewModelTest.kt
@@ -1,0 +1,98 @@
+package com.example.rise.ui.mainActivity
+
+import android.app.Activity
+import android.content.Intent
+import app.cash.turbine.test
+import com.example.rise.data.auth.AuthStateProvider
+import com.example.rise.data.auth.SignInIntentProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import com.example.rise.util.MainDispatcherRule
+import io.mockk.every
+import io.mockk.mockk
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainActivityViewModelTest {
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val defaultIntent = mockk<android.content.Intent> {
+        every { action } returns "sign-in"
+    }
+
+    @Test
+    fun `emits sign-in event when user is signed out`() = runTest {
+        val authState = FakeAuthStateProvider(signedIn = false)
+        val signInProvider = FakeSignInIntentProvider(defaultIntent)
+        val viewModel = MainActivityViewModel(authState, signInProvider)
+
+        viewModel.events.test {
+            viewModel.onStart()
+
+            val event = awaitItem()
+            assertTrue(event is MainActivityViewModel.MainActivityEvent.LaunchSignIn)
+            assertEquals(defaultIntent.action, (event as MainActivityViewModel.MainActivityEvent.LaunchSignIn).intent.action)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `does not relaunch sign-in when result succeeds`() = runTest {
+        val authState = FakeAuthStateProvider(signedIn = false)
+        val signInProvider = FakeSignInIntentProvider(defaultIntent)
+        val viewModel = MainActivityViewModel(authState, signInProvider)
+
+        viewModel.events.test {
+            viewModel.onStart()
+            awaitItem()
+
+            authState.setSignedIn(true)
+            viewModel.onSignInResult(Activity.RESULT_OK)
+
+            assertTrue(viewModel.uiState.value.isUserSignedIn)
+            assertFalse(viewModel.uiState.value.isSigningIn)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `retries sign-in when result fails`() = runTest {
+        val authState = FakeAuthStateProvider(signedIn = false)
+        val signInProvider = FakeSignInIntentProvider(defaultIntent)
+        val viewModel = MainActivityViewModel(authState, signInProvider)
+
+        viewModel.events.test {
+            viewModel.onStart()
+            awaitItem()
+
+            viewModel.onSignInResult(Activity.RESULT_CANCELED)
+
+            val retry = awaitItem()
+            assertTrue(retry is MainActivityViewModel.MainActivityEvent.LaunchSignIn)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class FakeAuthStateProvider(private var signedIn: Boolean) : AuthStateProvider {
+        override fun isSignedIn(): Boolean = signedIn
+
+        override fun currentUserId(): String? = if (signedIn) "id" else null
+
+        override fun currentUserDisplayName(): String? = if (signedIn) "name" else null
+
+        fun setSignedIn(value: Boolean) {
+            signedIn = value
+        }
+    }
+
+    private class FakeSignInIntentProvider(private val intent: Intent) : SignInIntentProvider {
+        override fun createSignInIntent(): Intent = intent
+    }
+}

--- a/app/src/test/java/com/example/rise/util/MainDispatcherRule.kt
+++ b/app/src/test/java/com/example/rise/util/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.example.rise.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.4.1'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.9.22-1.0.16"
     }
 }
 


### PR DESCRIPTION
## Summary
- replace manual view-model wiring with Koin-provided lazy delegates in the base activity/fragment and register repositories plus view models through the application module
- move the chat, people, and dashboard screens onto state/event driven view models backed by Firestore repositories, updating the UI layers to observe the new state flows
- add coroutine-based unit tests for the view models and update Gradle to enable Glide's KSP processor along with coroutine/testing dependencies
- introduce DI-driven auth helpers and move Splash/Main activities to consume their navigation and sign-in logic from view-model events with dedicated tests

## Testing
- ./gradlew --no-daemon --console=plain assembleDebug
- ./gradlew --no-daemon --console=plain test

------
https://chatgpt.com/codex/tasks/task_e_68da8066ba48832280f19f7761e4703c